### PR TITLE
Use commit message instead of the SHA in fixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Note that `git absorb` does _not_ use the system libgit2. This means you do not 
 ## Usage
 
 1. `git add` any changes that you want to absorb. By design, `git absorb` will only consider content in the git index.
-2. `git absorb`. This will create a sequence of commits on `HEAD`. Each commit will have a `fixup!` message indicating the SHA of the commit it should be squashed into.
+2. `git absorb`. This will create a sequence of commits on `HEAD`. Each commit will have a `fixup!` message indicating the message (if unique) or SHA of the commit it should be squashed into.
 3. If you are satisfied with the output, `git rebase -i --autosquash` to squash the `fixup!` commits into their predecessors. You can set the [`GIT_SEQUENCE_EDITOR`](https://stackoverflow.com/a/29094904) environment variable if you don't need to edit the rebase TODO file.
 4. If you are not satisfied (or if something bad happened), `git reset --soft` to the pre-absorption commit to recover your old state. (You can find the commit in question with `git reflog`.) And if you think `git absorb` is at fault, please [file an issue](https://github.com/tummychow/git-absorb/issues/new).
 


### PR DESCRIPTION
Hi @tummychow,

first of all: amazing project!!
Would it be possible to use the commit message instead of the SHA in the fixup?
Many tools do this (e.g. Magit in Emacs) and imo it makes sense because it will be both more readable and also continue to work if another rebase creates new SHAs.
I just hacked this together in the Github editor because, so it might not even compile, but I hope the intent is clear 😃