### PR TITLE
Fall back gracefully if user.{name,email} not set

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,9 @@ pub fn run(config: &Config) -> Result<(), failure::Error> {
            "index" => format!("{:?}", index),
     );
 
-    let signature = repo.signature()?;
+    let signature = repo
+        .signature()
+        .or_else(|_| git2::Signature::now("nobody", "nobody@example.com"))?;
     let mut head_commit = repo.head()?.peel_to_commit()?;
 
     let mut patches_considered = 0usize;


### PR DESCRIPTION
Git has defaults for if the user.name and user.email configuration options aren't set, but these [aren't implemented by libgit2](https://github.com/libgit2/libgit2/issues/1528). They make the case that these are an implementation detail of Git, which is entirely correct. Fortunately, git-absorb doesn't really need signatures in order to function. We just lose the author check, and create our temporary commits using a dummy signature. Since they're temporary anyway, this doesn't matter.

Now, since git-absorb is intended to be used as a subcommand of the Git CLI, think it would actually make more sense for it to use Git's default signature implementation, rather than libgit2's. This would make it more consistent with every other git command. Git provides a nice plumbing API to get this value: `git var GIT_AUTHOR_IDENT`. So, in my mind the more correct fix would actually be to use that, but that would require spawning a git process, which git-absorb doesn't currently do. Hence this more conservative patch. I don't think it would be a big problem though -- it's very unlikely git-absorb would ever be used without git being available.