### PR TITLE
Create man page to enable git help absorb

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -4,3 +4,6 @@ git-absorb.1: git-absorb.txt
 	$(if $(shell which a2x),,$(error "No a2x in PATH; install asciidoc."))
 	$(info Building manpage. This may take a few moments...)
 	a2x -L -d manpage -f manpage git-absorb.txt
+
+clean:
+	rm -f git-absorb.1 git-absorb.xml

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -1,0 +1,6 @@
+build-manpage: git-absorb.1
+
+git-absorb.1: git-absorb.txt
+	$(if $(shell which a2x),,$(error "No a2x in PATH; install asciidoc."))
+	$(info Building manpage. This may take a few moments...)
+	a2x -L -d manpage -f manpage git-absorb.txt

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,13 @@
+git-absorb manual
+=================
+
+This project's man page `git-absorb.1.gz` can be generated from `git-absorb.txt`
+by running `make`.
+
+Build dependencies
+------------------
+
+- [asciidoc][] (tested with version 8.6.10)
+- GNU Make
+
+[asciidoc]: http://www.methods.co.nz/asciidoc/

--- a/Documentation/git-absorb.1
+++ b/Documentation/git-absorb.1
@@ -156,7 +156,7 @@ is at fault, please [file an issue][]\&.
 .RS 4
 .\}
 .nf
-[`GIT_SEQUENCE_EDITOR`]: https://stackoverflow\&.com/a/29094904
+[GIT_SEQUENCE_EDITOR]: https://stackoverflow\&.com/a/29094904
 [file an issue]: https://github\&.com/tummychow/git\-absorb/issues/new
 .fi
 .if n \{\

--- a/Documentation/git-absorb.1
+++ b/Documentation/git-absorb.1
@@ -1,0 +1,197 @@
+'\" t
+.\"     Title: git-absorb
+.\"    Author: [see the "AUTHOR" section]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 10/18/2019
+.\"    Manual: git absorb
+.\"    Source: git-absorb 0.5.0
+.\"  Language: English
+.\"
+.TH "GIT\-ABSORB" "1" "10/18/2019" "git\-absorb 0\&.5\&.0" "git absorb"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+git-absorb \- Automatically absorb staged changes into your current branch
+.SH "SYNOPSIS"
+.sp
+.nf
+\fIgit absorb\fR [FLAGS] [OPTIONS]
+.fi
+.SH "DESCRIPTION"
+.sp
+You have a feature branch with a few commits\&. Your teammate reviewed the branch and pointed out a few bugs\&. You have fixes for the bugs, but you don\(cqt want to shove them all into an opaque commit that says fixes, because you believe in atomic commits\&. Instead of manually finding commit SHAs for git commit \-\-fixup, or running a manual interactive rebase, do this:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+$ git add $FILES_YOU_FIXED
+
+$ git absorb \-\-and\-rebase
+  (or)
+$ git absorb
+$ git rebase \-i \-\-autosquash master
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+git absorb will automatically identify which commits are safe to modify, and which indexed changes belong to each of those commits\&. It will then write fixup! commits for each of those changes\&. You can check its output manually if you don\(cqt trust it, and then fold the fixups into your feature branch with git\(cqs built\-in autosquash functionality\&.
+.SH "FLAGS"
+.PP
+\-r, \-\-and\-rebase
+.RS 4
+Run rebase if successful
+.RE
+.PP
+\-n, \-\-dry\-run
+.RS 4
+Don\(cqt make any actual changes
+.RE
+.PP
+\-f, \-\-force
+.RS 4
+Skip safety checks
+.RE
+.PP
+\-h, \-\-help
+.RS 4
+Prints help information
+.RE
+.PP
+\-V, \-\-version
+.RS 4
+Prints version information
+.RE
+.PP
+\-v, \-\-verbose
+.RS 4
+Display more output
+.RE
+.SH "OPTIONS"
+.PP
+\-b <base>, \-\-base <base>
+.RS 4
+Use this commit as the base of the absorb stack
+.RE
+.SH "USAGE"
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 1.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  1." 4.2
+.\}
+git add
+any changes that you want to absorb\&. By design,
+git absorb
+will only consider content in the git index\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 2.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  2." 4.2
+.\}
+git absorb\&. This will create a sequence of commits on
+HEAD\&. Each commit will have a
+fixup!
+message indicating the message (if unique) or SHA of the commit it should be squashed into\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 3.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  3." 4.2
+.\}
+If you are satisfied with the output,
+git rebase \-i \-\-autosquash
+to squash the
+fixup!
+commits into their predecessors\&. You can set the [GIT_SEQUENCE_EDITOR][] environment variable if you don\(cqt need to edit the rebase TODO file\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04' 4.\h'+01'\c
+.\}
+.el \{\
+.sp -1
+.IP "  4." 4.2
+.\}
+If you are not satisfied (or if something bad happened),
+git reset \-\-soft
+to the pre\-absorption commit to recover your old state\&. (You can find the commit in question with
+git reflog\&.) And if you think
+git absorb
+is at fault, please [file an issue][]\&.
+.RE
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+[`GIT_SEQUENCE_EDITOR`]: https://stackoverflow\&.com/a/29094904
+[file an issue]: https://github\&.com/tummychow/git\-absorb/issues/new
+.fi
+.if n \{\
+.RE
+.\}
+.SH "CONFIGURATION"
+.SS "STACK SIZE"
+.sp
+When run without \-\-base, git\-absorb will only search for candidate commits to fixup within a certain range (by default 10)\&. If you get an error like this:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+WARN stack limit reached, limit: 10
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+edit your local or global \&.gitconfig and add the following section:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+[absorb]
+    maxStack=50 # Or any other reasonable value for your project
+.fi
+.if n \{\
+.RE
+.\}
+.SH "GITHUB PROJECT"
+.sp
+https://github\&.com/tummychow/git\-absorb
+.SH "AUTHOR"
+.sp
+Stephen Jung <tummychow511@gmail\&.com>

--- a/Documentation/git-absorb.txt
+++ b/Documentation/git-absorb.txt
@@ -85,7 +85,7 @@ SHA of the commit it should be squashed into.
 
 3. If you are satisfied with the output, `git rebase -i --autosquash` to
 squash the `fixup!` commits into their predecessors. You can set the
-[`GIT_SEQUENCE_EDITOR`][] environment variable if you don't need to edit
+[GIT_SEQUENCE_EDITOR][] environment variable if you don't need to edit
 the rebase TODO file.
 
 4. If you are not satisfied (or if something bad happened), `git reset
@@ -94,7 +94,7 @@ find the commit in question with `git reflog`.) And if you think `git
 absorb` is at fault, please [file an issue][].
 
 .............................................................................
-[`GIT_SEQUENCE_EDITOR`]: https://stackoverflow.com/a/29094904
+[GIT_SEQUENCE_EDITOR]: https://stackoverflow.com/a/29094904
 [file an issue]: https://github.com/tummychow/git-absorb/issues/new
 .............................................................................
 

--- a/Documentation/git-absorb.txt
+++ b/Documentation/git-absorb.txt
@@ -1,0 +1,130 @@
+:man source:   git-absorb
+:man version:  0.5.0
+:man manual:   git absorb
+
+git-absorb(1)
+=============
+
+NAME
+----
+git-absorb - Automatically absorb staged changes into your current branch
+
+SYNOPSIS
+--------
+[verse]
+'git absorb' [FLAGS] [OPTIONS]
+
+DESCRIPTION
+-----------
+
+You have a feature branch with a few commits. Your teammate reviewed the
+branch and pointed out a few bugs. You have fixes for the bugs, but you
+don't want to shove them all into an opaque commit that says `fixes`,
+because you believe in atomic commits. Instead of manually finding commit
+SHAs for `git commit --fixup`, or running a manual interactive rebase, do
+this:
+
+.............................................................................
+$ git add $FILES_YOU_FIXED
+
+$ git absorb --and-rebase
+  (or)
+$ git absorb
+$ git rebase -i --autosquash master
+.............................................................................
+
+`git absorb` will automatically identify which commits are safe to modify,
+and which indexed changes belong to each of those commits. It will then
+write `fixup!` commits for each of those changes. You can check its output
+manually if you don't trust it, and then fold the fixups into your feature
+branch with git's built-in autosquash functionality.
+
+FLAGS
+-----
+
+-r::
+--and-rebase::
+        Run rebase if successful
+
+-n::
+--dry-run::
+        Don't make any actual changes
+
+-f::
+--force::
+        Skip safety checks
+
+-h::
+--help::
+        Prints help information
+
+-V::
+--version::
+        Prints version information
+
+-v::
+--verbose::
+        Display more output
+
+OPTIONS
+-------
+
+-b <base>::
+--base <base>::
+        Use this commit as the base of the absorb stack
+
+USAGE
+-----
+
+1. `git add` any changes that you want to absorb. By design, `git absorb`
+will only consider content in the git index.
+
+2. `git absorb`. This will create a sequence of commits on `HEAD`. Each
+commit will have a `fixup!` message indicating the message (if unique) or
+SHA of the commit it should be squashed into.
+
+3. If you are satisfied with the output, `git rebase -i --autosquash` to
+squash the `fixup!` commits into their predecessors. You can set the
+[`GIT_SEQUENCE_EDITOR`][] environment variable if you don't need to edit
+the rebase TODO file.
+
+4. If you are not satisfied (or if something bad happened), `git reset
+--soft` to the pre-absorption commit to recover your old state. (You can
+find the commit in question with `git reflog`.) And if you think `git
+absorb` is at fault, please [file an issue][].
+
+.............................................................................
+[`GIT_SEQUENCE_EDITOR`]: https://stackoverflow.com/a/29094904
+[file an issue]: https://github.com/tummychow/git-absorb/issues/new
+.............................................................................
+
+CONFIGURATION
+-------------
+
+STACK SIZE
+~~~~~~~~~~
+
+When run without `--base`, git-absorb will only search for candidate
+commits to fixup within a certain range (by default 10). If you get an
+error like this:
+
+.............................................................................
+WARN stack limit reached, limit: 10
+.............................................................................
+
+edit your local or global `.gitconfig` and add the following section:
+
+.............................................................................
+[absorb]
+    maxStack=50 # Or any other reasonable value for your project
+.............................................................................
+
+GITHUB PROJECT
+--------------
+
+https://github.com/tummychow/git-absorb
+
+AUTHOR
+------
+
+Stephen Jung <tummychow511@gmail.com>


### PR DESCRIPTION
Overview
---

This PR introduces a man page for `git help absorb`. Fixes #2. Content was largely adapted from the existing README and `--help` output.

Without a man page for `git-absorb`, both `git help absorb` and `git absorb --help` produce this error:

    No manual entry for git-absorb

Although `git-absorb --help` does show a help page, the syntax required for this to work atypical and unconventional.

New users are likely to easily forget the wording of `--and-rebase`. I would find this help page useful. See also #2.

Viewing the man page without installing
---

You can [preview the man page][preview] without moving it into a system man directory via

    man ./Documentation/git-absorb.1

Editing the man page
----

`Documentation/git-absorb.txt` contains the human-readable source for the man page. It uses the [asciidoc][] format, which you can largely pick up by copying the style already used in the source file. If you need more advanced text formatting, titles, lists, etc., see the [asciidoc user guide][].

To build the man page after editing, run `make`. This requires that you have asciidoc installed.

The version number in the man page must be updated for each new release.

Man Page Installation to System
---

As @giodamelio pointed out, the cargo community [is still working on a solution for installing man pages][cargo support issue]. I recommend following that discussion and adding support to this project's `cargo.toml` once support becomes available.

In the meantime, the man page can be installed via the homebrew formula. I have patch ready to be submitted as a pull request once a version of git-absorb is released that contains the man page. I've tested this patch successfully locally.

```diff
diff --git a/Formula/git-absorb.rb b/Formula/git-absorb.rb
index 4db7db5dfc..a8024a9bd8 100644
--- a/Formula/git-absorb.rb
+++ b/Formula/git-absorb.rb
@@ -16,6 +17,10 @@ class GitAbsorb < Formula

   def install
     system "cargo", "install", "--root", prefix, "--path", "."
+
+    man_path = File.join(prefix, "share", "man", "man1")
+    mkdir_p man_path
+    cp "./Documentation/git-absorb.1", man_path
   end

   test do
```

[asciidoc]: http://asciidoc.org
[asciidoc user guide]: http://asciidoc.org/asciidoc.css-embedded.html
[cargo support issue]: https://github.com/rust-lang/cargo/issues/2729
[preview]: https://gist.github.com/nilbus/78549c85ad0282425ee78f52a9263b2d