### PR TITLE
Activate simplify_first_parent in revwalk

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -33,6 +33,7 @@ pub fn working_stack<'repo>(
     let mut revwalk = repo.revwalk()?;
     revwalk.set_sorting(git2::Sort::TOPOLOGICAL);
     revwalk.push_head()?;
+    revwalk.simplify_first_parent();
     debug!(logger, "head pushed"; "head" => head.name());
 
     let base_commit = match user_provided_base {


### PR DESCRIPTION
This PR enables `simplify_first_parent` for the enumeration of the git history.

While working in a huge repository, I observed that the `revwalk` through the git history can take a while. 
Since the last merge commit is used as the termination criterion in the loop below, I think the case where `revwalk` has to push more than one parent commit can safely be ignored.

@tummychow, do you see any problems with enabling `simplify_first_parent`?