### PR TITLE
README: clarify two-step usage, and use "staging" terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git absorb --and-rebase
 # or: git absorb && git rebase -i --autosquash master
 ```
 
-`git absorb` will automatically identify which commits are safe to modify, and which indexed changes belong to each of those commits. It will then write `fixup!` commits for each of those changes. You can check its output manually if you don't trust it, and then fold the fixups into your feature branch with git's built-in autosquash functionality.
+`git absorb` will automatically identify which commits are safe to modify, and which staged changes belong to each of those commits. It will then write `fixup!` commits for each of those changes. You can check its output manually if you don't trust it, and then fold the fixups into your feature branch with git's built-in autosquash functionality.
 
 ## Installing
 
@@ -39,7 +39,7 @@ Alternatively, `git absorb` is available in the following system package manager
 
 ## Usage
 
-1. `git add` any changes that you want to absorb. By design, `git absorb` will only consider content in the git index.
+1. `git add` any changes that you want to absorb. By design, `git absorb` will only consider content in the git index (staging area).
 2. `git absorb`. This will create a sequence of commits on `HEAD`. Each commit will have a `fixup!` message indicating the message (if unique) or SHA of the commit it should be squashed into.
 3. If you are satisfied with the output, `git rebase -i --autosquash` to squash the `fixup!` commits into their predecessors. You can set the [`GIT_SEQUENCE_EDITOR`](https://stackoverflow.com/a/29094904) environment variable if you don't need to edit the rebase TODO file.
 4. If you are not satisfied (or if something bad happened), `git reset --soft` to the pre-absorption commit to recover your old state. (You can find the commit in question with `git reflog`.) And if you think `git absorb` is at fault, please [file an issue](https://github.com/tummychow/git-absorb/issues/new).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You have a feature branch with a few commits. Your teammate reviewed the branch 
 ```
 git add $FILES_YOU_FIXED
 git absorb --and-rebase
-# or: git rebase -i --autosquash master
+# or: git absorb && git rebase -i --autosquash master
 ```
 
 `git absorb` will automatically identify which commits are safe to modify, and which indexed changes belong to each of those commits. It will then write `fixup!` commits for each of those changes. You can check its output manually if you don't trust it, and then fold the fixups into your feature branch with git's built-in autosquash functionality.

--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ You have a feature branch with a few commits. Your teammate reviewed the branch 
 ```
 git add $FILES_YOU_FIXED
 git absorb --and-rebase
-# or: git absorb && git rebase -i --autosquash master
 ```
 
 `git absorb` will automatically identify which commits are safe to modify, and which staged changes belong to each of those commits. It will then write `fixup!` commits for each of those changes.
 
-With the `--and-rebase` flag, these fixup commits will be automatically integrated into the corresponding ones. Alternatively, you can check its output manually if you don't trust it, and then fold the fixups into your feature branch with git's built-in [autosquash](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt-rebaseautoStash) functionality:
+With the `--and-rebase` flag, these fixup commits will be automatically integrated into the corresponding ones. Alternatively, you can check its output manually if you don't trust it, and then fold the fixups into your feature branch with git's built-in [autosquash](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---autosquash) functionality:
 
 ```
 git add $FILES_YOU_FIXED

--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ git absorb --and-rebase
 # or: git absorb && git rebase -i --autosquash master
 ```
 
-`git absorb` will automatically identify which commits are safe to modify, and which staged changes belong to each of those commits. It will then write `fixup!` commits for each of those changes. You can check its output manually if you don't trust it, and then fold the fixups into your feature branch with git's built-in autosquash functionality.
+`git absorb` will automatically identify which commits are safe to modify, and which staged changes belong to each of those commits. It will then write `fixup!` commits for each of those changes.
+
+With the `--and-rebase` flag, these fixup commits will be automatically integrated into the corresponding ones. Alternatively, you can check its output manually if you don't trust it, and then fold the fixups into your feature branch with git's built-in [autosquash](https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt-rebaseautoStash) functionality:
+
+```
+git add $FILES_YOU_FIXED
+git absorb
+git log # check the auto-generated fixup commits
+git rebase -i --autosquash master
+```
 
 ## Installing
 


### PR DESCRIPTION
- Expand the usage section to clarify what the `--and-rebase` flag does, and how the alternative, two-step operation works
- Introduce "staging" terminology which is a common (and IMO more intuitive) way to refer to the [index](https://git-scm.com/docs/gitglossary#def_index).