### PR TITLE
Allow --force to continue past "HEAD is not a branch" check.

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -25,7 +25,11 @@ pub fn working_stack<'repo>(
     debug!(logger, "head found"; "head" => head.name());
 
     if !head.is_branch() {
-        return Err(anyhow!("HEAD is not a branch"));
+        if !force {
+            return Err(anyhow!("HEAD is not a branch"));
+        } else {
+            warn!(logger, "HEAD is not a branch, but --force used to continue.");
+        }
     }
 
     let mut revwalk = repo.revwalk()?;


### PR DESCRIPTION
Fixes #47.

I tried to use this while in an edit stage of an interactive rebase,
hoping to detach the current commit and absorb some chunks above. This
should allow that.

I assume I interpreted your feedback on #47 correctly. Happy to reword
or restructure.

Please note: I'm coding blind. I don't have any rust tooling
or (successful) history with it.