### PR TITLE
README.md: update installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Alternatively, `git absorb` is available in the following system package manager
 
 | Repository                  | Command                                      |
 | --------------------------- | -------------------------------------------- |
-| AUR                         | `yay -S git-absorb`                          |
+| Arch Linux                  | `pacman -S git-absorb`                       |
 | DPorts                      | `pkg install git-absorb`                     |
 | FreeBSD Ports               | `pkg install git-absorb`                     |
 | Homebrew and Linuxbrew      | `brew install git-absorb`                    |


### PR DESCRIPTION
`git-absorb` is moved to the [community] repository: https://archlinux.org/packages/community/x86_64/git-absorb/
