### PR TITLE
Statically link msvcrt for Windows-msvc target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
Avoid the user needing to have MS VC++ Redistributables/VCRUNTIME140.dll