### PR TITLE
Release infra

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,173 @@
+# The way this works is the following:
+#
+# The create-release job runs purely to initialize the GitHub release itself
+# and to output upload_url for the following job.
+#
+# The build-release job runs only once create-release is finished. It gets the
+# release upload URL from create-release job outputs, then builds the release
+# executables for each supported platform and attaches them as release assets
+# to the previously created release.
+#
+# The key here is that we create the release only once.
+#
+# Reference:
+# https://eugene-babichenko.github.io/blog/2020/05/09/github-actions-cross-platform-auto-releases/
+# Adjusted from: https://github.com/BurntSushi/ripgrep/blob/df83b8b44426b3f2179/.github/workflows/release.yml
+
+name: release
+on:
+  push:
+    # Enable when testing release infrastructure on a branch + set a GA_VERSION a few lines below
+    # branches:
+    # -  tummychow/work
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  create-release:
+    name: create-release
+    runs-on: ubuntu-latest
+#    env:
+      # Set to force version number, e.g., when no tag exists.
+#      GA_VERSION: TEST-0.0.4
+    outputs:
+      upload_url: ${{ steps.release.outputs.upload_url }}
+      GA_VERSION: ${{ env.GA_VERSION }}
+    steps:
+      - name: Get the release version from the tag
+        shell: bash
+        if: env.GA_VERSION == ''
+        run: |
+          # Apparently, this is the right way to get a tag name. Really?
+          #
+          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
+          echo "GA_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "version is: ${{ env.GA_VERSION }}"
+      - name: Create GitHub release
+        # Todo: Maybe replace it with https://github.com/softprops/action-gh-release to generate a nice changelog?
+        id: release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.GA_VERSION }}
+          release_name: ${{ env.GA_VERSION }}
+
+  build-release:
+    name: build-release
+    needs: ['create-release']
+    runs-on: ${{ matrix.os }}
+    env:
+      # For some builds, we use cross to test on 32-bit and big-endian
+      # systems.
+      CARGO: cargo
+      # When CARGO is set to CROSS, this is set to `--target matrix.target`.
+      TARGET_FLAGS: ""
+      # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
+      TARGET_DIR: ./target
+      # Emit backtraces on panics.
+      RUST_BACKTRACE: 1
+      # Build static releases with PCRE2.
+      PCRE2_SYS_STATIC: 1
+    strategy:
+      matrix:
+        build: [linux, linux-arm, macos, win-msvc, win-gnu, win32-msvc]
+        include:
+          # Use an old linux distro to link against an old glibc to not get problems on older distros
+          - build: linux
+            os: ubuntu-18.04
+            rust: nightly
+            target: x86_64-unknown-linux-musl
+          - build: linux-arm
+            os: ubuntu-18.04
+            rust: nightly
+            target: arm-unknown-linux-gnueabihf
+          - build: macos
+            os: macos-latest
+            rust: nightly
+            target: x86_64-apple-darwin
+          - build: win-msvc
+            os: windows-2019
+            rust: nightly
+            target: x86_64-pc-windows-msvc
+          - build: win-gnu
+            os: windows-2019
+            rust: nightly-x86_64-gnu
+            target: x86_64-pc-windows-gnu
+          - build: win32-msvc
+            os: windows-2019
+            rust: nightly
+            target: i686-pc-windows-msvc
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
+          target: ${{ matrix.target }}
+
+      - name: Use Cross
+        shell: bash
+        run: |
+          cargo install cross
+          echo "CARGO=cross" >> $GITHUB_ENV
+          echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
+          echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
+
+      - name: Show command used for Cargo
+        run: |
+          echo "cargo command is: ${{ env.CARGO }}"
+          echo "target flag is: ${{ env.TARGET_FLAGS }}"
+          echo "target dir is: ${{ env.TARGET_DIR }}"
+
+      - name: Build release binary
+        run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }}
+
+      - name: Strip release binary (linux and macos)
+        if: matrix.build == 'linux' || matrix.build == 'macos'
+        run: strip "target/${{ matrix.target }}/release/git-absorb"
+
+      - name: Strip release binary (linux-arm)
+        if: matrix.build == 'linux-arm'
+        run: |
+          docker run --rm -v \
+            "$PWD/target:/target:Z" \
+            rustembedded/cross:arm-unknown-linux-gnueabihf \
+            arm-linux-gnueabihf-strip \
+            /target/arm-unknown-linux-gnueabihf/release/git-absorb
+
+      - name: Build archive
+        shell: bash
+        run: |
+          outdir="${{ env.TARGET_DIR }}/release"
+          staging="git-absorb-${{ needs.create-release.outputs.GA_VERSION }}-${{ matrix.target }}"
+          mkdir -p "$staging"/doc
+
+          cp {README.md,LICENSE.md} "$staging/"
+          cp Documentation/{git-absorb.1,git-absorb.txt} "$staging/doc/"
+
+          if [ "${{ matrix.os }}" = "windows-2019" ]; then
+            cp "target/${{ matrix.target }}/release/git-absorb.exe" "$staging/"
+            7z a "$staging.zip" "$staging"
+            echo "ASSET=$staging.zip" >> $GITHUB_ENV
+          else
+            cp "target/${{ matrix.target }}/release/git-absorb" "$staging/"
+            tar czf "$staging.tar.gz" "$staging"
+            echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+          fi
+
+      - name: Upload release archive
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.create-release.outputs.upload_url }}
+          asset_path: ${{ env.ASSET }}
+          asset_name: ${{ env.ASSET }}
+          asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target/
+.idea


### PR DESCRIPTION
Example run and corresponding release: 
* run: https://github.com/jankatins/git-absorb/actions/runs/2435141034
* release: https://github.com/jankatins/git-absorb/releases/tag/1.2.4

This is based on a master push with a example tag. I had some problems making it work in branch but this should be more or less the same as a regular release. 

Workflow after merging this:
* Make a nice commit with some summary description of the release -> this shows up as plain text on the release page and does not format markdown :-(
* Tag a commit and push the tag
* Action will create a release based on the commit message of the latest commit
* (Maybe: copy the release body, edit the release, paste the release body into it and adjust -> here markdown now works)
* Action will add artifacts based on that release

Currently, the binaries are in a archive (together with some doc stuff), so any install script needs to be adjusted to untar/unzip and get the binary from a versioned subdir (zinit can do that, so I'm happy) instead of renaming/linking to the versioned binary.

Example extract:
```
[16:18:15] λ  extract git-absorb-TEST-0.0.3-x86_64-unknown-linux-musl.tar.gz
git-absorb-TEST-0.0.3-x86_64-unknown-linux-musl/
git-absorb-TEST-0.0.3-x86_64-unknown-linux-musl/README.md
git-absorb-TEST-0.0.3-x86_64-unknown-linux-musl/doc/
git-absorb-TEST-0.0.3-x86_64-unknown-linux-musl/doc/git-absorb.1
git-absorb-TEST-0.0.3-x86_64-unknown-linux-musl/doc/git-absorb.txt
git-absorb-TEST-0.0.3-x86_64-unknown-linux-musl/LICENSE.md
git-absorb-TEST-0.0.3-x86_64-unknown-linux-musl/git-absorb
```

Closes: #39 #59

Tested on linux and mac by running ` git-absorb --help`