### PR TITLE
Remove unused `by_old` function

### DIFF
--- a/src/owned.rs
+++ b/src/owned.rs
@@ -42,9 +42,6 @@ impl Diff {
 
         Ok(ret)
     }
-    pub fn by_old(&self, path: &[u8]) -> Option<&Patch> {
-        self.by_old.get(path).map(|&idx| &self.patches[idx])
-    }
     pub fn by_new(&self, path: &[u8]) -> Option<&Patch> {
         self.by_new.get(path).map(|&idx| &self.patches[idx])
     }


### PR DESCRIPTION
This PR removes the following warning that I came across while building [`git-absorb`](https://archlinux.org/packages/community/x86_64/git-absorb/):

```
   Compiling git-absorb v0.6.7 (/build/git-absorb/src/git-absorb-0.6.7)
warning: associated function is never used: `by_old`
  --> src/owned.rs:45:12
   |
45 |     pub fn by_old(&self, path: &[u8]) -> Option<&Patch> {
   |            ^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default
```

