### PR TITLE
bump git2/libgit2-sys locked dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.11"
+version = "0.13.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e094214efbc7fdbbdee952147e493b00e99a4e52817492277e98967ae918165"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
 dependencies = [
  "bitflags",
  "libc",
@@ -241,9 +241,9 @@ checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.13+1.0.1"
+version = "0.12.26+1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069eea34f76ec15f2822ccf78fe0cdb8c9016764d0a12865278585a74dbdeae5"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
There is a double free in libgit2 that is fixed somewhere between v1.0.0 and v1.1.0. This means that the transitive libgit2-sys dependency needs to be after 0.12.14+1.1.0.

This manifests itself via the following error message on certain repositories:

    $ git absorb
    free(): double free detected in tcache 2
    Aborted (core dumped)

Bump git2 to the latest version, which also updates the transitive libgit2-sys (and libgit2) dependency.

Fixes #69