### PR TITLE
Dev/add new match file flag

### DIFF
--- a/Documentation/git-absorb.1
+++ b/Documentation/git-absorb.1
@@ -1,13 +1,13 @@
 '\" t
 .\"     Title: git-absorb
 .\"    Author: [see the "AUTHOR" section]
-.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
-.\"      Date: 10/18/2019
+.\" Generator: DocBook XSL Stylesheets vsnapshot <http://docbook.sf.net/>
+.\"      Date: 04/06/2023
 .\"    Manual: git absorb
 .\"    Source: git-absorb 0.5.0
 .\"  Language: English
 .\"
-.TH "GIT\-ABSORB" "1" "10/18/2019" "git\-absorb 0\&.5\&.0" "git absorb"
+.TH "GIT\-ABSORB" "1" "04/06/2023" "git\-absorb 0\&.5\&.0" "git absorb"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -69,6 +69,11 @@ Don\(cqt make any actual changes
 \-f, \-\-force
 .RS 4
 Skip safety checks
+.RE
+.PP
+\-w, \-\-whole\-file
+.RS 4
+Match the first commit touching the same file as the current hunk\&. Use this with care!
 .RE
 .PP
 \-h, \-\-help

--- a/Documentation/git-absorb.txt
+++ b/Documentation/git-absorb.txt
@@ -54,6 +54,11 @@ FLAGS
 --force::
         Skip safety checks
 
+-w::
+--whole-file::
+        Match the first commit touching the same file as the current hunk.
+        Use this with care!
+
 -h::
 --help::
         Prints help information

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,13 @@ fn main() {
                 .long("gen-completions")
                 .takes_value(true)
                 .possible_values(&["bash", "fish", "zsh", "powershell", "elvish"]),
+        )
+        .arg(
+            clap::Arg::with_name("whole-file")
+                .help("Match the change against the complete file   ")
+                .short("w")
+                .long("--whole-file")
+                .takes_value(false),
         );
     let mut args_clone = args.clone();
     let args = args.get_matches();
@@ -104,6 +111,7 @@ fn main() {
         force: args.is_present("force"),
         base: args.value_of("base"),
         and_rebase: args.is_present("and-rebase"),
+        whole_file: args.is_present("whole-file"),
         logger: &logger,
     }) {
         crit!(logger, "absorb failed"; "err" => e.to_string());


### PR DESCRIPTION
Add new option to match the current hunk file with the first commit touching that file as discussed in #56. Hence, these PULL should fix issue #56.

@tummychow this was suspiciously easy to add and I'm not so sure about the solution. From what I understood, as we pass the first `match` expression, then we know the current hunk file is touched by that commit and hence, we can just bail out. not sure if there's any subtle tie I'm missing. As stated in #76, I'm very very new with rust.

I was also wondering if we should keep the same mechanism as before (doing the commutations) and just add this flag check in the end of the loop so that, even with the flag, we use it as a fallback mechanism.  