### PR TITLE
Migrate release CI to taiki-e/upload-rust-binary-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,155 +1,50 @@
-# The way this works is the following:
-#
-# The create-release job runs purely to initialize the GitHub release itself
-# and to output upload_url for the following job.
-#
-# The build-release job runs only once create-release is finished. It gets the
-# release upload URL from create-release job outputs, then builds the release
-# executables for each supported platform and attaches them as release assets
-# to the previously created release.
-#
-# The key here is that we create the release only once.
-#
-# Reference:
-# https://eugene-babichenko.github.io/blog/2020/05/09/github-actions-cross-platform-auto-releases/
-# Adjusted from: https://github.com/BurntSushi/ripgrep/blob/df83b8b44426b3f2179/.github/workflows/release.yml
+name: Release
 
-name: release
+permissions:
+  contents: write
+
 on:
   push:
-    # Enable when testing release infrastructure on a branch + set a GA_VERSION a few lines below
-    # branches:
-    # -  release-twiddling
+    branches:
+      - release-twiddling
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+
 jobs:
   create-release:
-    name: create-release
     runs-on: ubuntu-latest
-    # env:
-      # Set to force version number, e.g., when no tag exists.
-      # GA_VERSION: TEST-0.6.8
-    outputs:
-      upload_url: ${{ steps.release.outputs.upload_url }}
-      GA_VERSION: ${{ env.GA_VERSION }}
     steps:
-      - name: Get the release version from the tag
-        shell: bash
-        if: env.GA_VERSION == ''
-        run: |
-          # Apparently, this is the right way to get a tag name. Really?
-          #
-          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
-          echo "GA_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "version is: ${{ env.GA_VERSION }}"
-      - name: Create GitHub release
-        # Todo: Maybe replace it with https://github.com/softprops/action-gh-release to generate a nice changelog?
-        id: release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v3
+      - uses: taiki-e/create-gh-release-action@v1
         with:
-          tag_name: ${{ env.GA_VERSION }}
-          release_name: ${{ env.GA_VERSION }}
+          # (required) GitHub token for creating GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}
 
-  build-release:
-    name: build-release
-    needs: ['create-release']
-    runs-on: ${{ matrix.os }}
-    env:
-      # Emit backtraces on panics.
-      RUST_BACKTRACE: 1
+  upload-assets:
     strategy:
       matrix:
-        build: [linux, linux-arm, macos, win-msvc, win-gnu]
         include:
-          # cross doesn't support the darwin/msvc targets unless you build their dockerfiles locally, due to licensing issues
-          # https://github.com/cross-rs/cross-toolchains
-          # so we only use it for the linux targets that require other architectures/libcs
-          - build: linux
+          - target: arm-unknown-linux-gnueabihf
             os: ubuntu-latest
-            rust: nightly
-            target: x86_64-unknown-linux-musl
-            cross: true
-          - build: linux-arm
-            os: ubuntu-latest
-            rust: nightly
-            target: arm-unknown-linux-gnueabihf
-            cross: true
-          - build: macos
+          - target: aarch64-apple-darwin
             os: macos-latest
-            rust: nightly
-            target: x86_64-apple-darwin
-            cross: false
-          - build: win-msvc
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+          - target: x86_64-pc-windows-gnu
             os: windows-latest
-            rust: nightly
-            target: x86_64-pc-windows-msvc
-            cross: false
-          - build: win-gnu
+          - target: x86_64-pc-windows-msvc
             os: windows-latest
-            rust: nightly-x86_64-gnu
-            target: x86_64-pc-windows-gnu
-            cross: false
-
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: taiki-e/upload-rust-binary-action@v1
         with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
+          # (required) Comma-separated list of binary names (non-extension portion of filename) to build and upload.
+          # Note that glob pattern is not supported yet.
+          bin: git-absorb
+          # (optional) Target triple, default is host triple.
           target: ${{ matrix.target }}
-
-      - name: Build release binary
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.cross }}
-          command: build
-          args: --release --verbose --target ${{ matrix.target }}
-
-      - name: Strip release binary (linux and macos)
-        if: matrix.build == 'linux' || matrix.build == 'macos'
-        run: strip "target/${{ matrix.target }}/release/git-absorb"
-
-      - name: Strip release binary (linux-arm)
-        if: matrix.build == 'linux-arm'
-        run: |
-          docker run --rm -v \
-            "$PWD/target:/target:Z" \
-            rustembedded/cross:arm-unknown-linux-gnueabihf \
-            arm-linux-gnueabihf-strip \
-            /target/arm-unknown-linux-gnueabihf/release/git-absorb
-
-      - name: Build archive
-        shell: bash
-        run: |
-          outdir="./target/${{ matrix.target }}/release"
-          staging="git-absorb-${{ needs.create-release.outputs.GA_VERSION }}-${{ matrix.target }}"
-          mkdir -p "$staging"/doc
-
-          cp {README.md,LICENSE.md} "$staging/"
-          cp Documentation/{git-absorb.1,git-absorb.txt} "$staging/doc/"
-
-          if [[ "${{ matrix.target }}" =~ .*windows.* ]]; then
-            cp "target/${{ matrix.target }}/release/git-absorb.exe" "$staging/"
-            7z a "$staging.zip" "$staging"
-            echo "ASSET=$staging.zip" >> $GITHUB_ENV
-          else
-            cp "target/${{ matrix.target }}/release/git-absorb" "$staging/"
-            tar czf "$staging.tar.gz" "$staging"
-            echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
-          fi
-
-      - name: Upload release archive
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ needs.create-release.outputs.upload_url }}
-          asset_path: ${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
-          asset_content_type: application/octet-stream
+          # (required) GitHub token for uploading assets to GitHub Releases.
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,6 @@ anyhow = "~1.0"
 
 [dev-dependencies]
 tempfile = "~3.1"
+
+[profile.release]
+strip = "debuginfo"


### PR DESCRIPTION
This retains the existing targets and adds a couple more that are supposed by [upload-rust-binary-action](https://github.com/taiki-e/upload-rust-binary-action).

Fixes #82 

TODO
- [ ] Restore release binary stripping
