### PR TITLE
autostage: automatically add everything to index if index was empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,17 @@ To always have this behavior, set
     oneFixupPerCommit = true
 ```
 
+### Auto-stage all changes if nothing staged
+
+By default, git-absorb will only consider files that you've staged to the index via `git add`. However, sometimes one wants to try and absorb from all changes, which would require to stage them first via `git add .`. To avoid this extra step, set
+
+```ini
+[absorb]
+    autoStageIfNothingStaged = true
+```
+
+which tells git-absorb, when no changes are staged, to auto-stage them all, create fixup commits where possible, and unstage remaining changes from the index.
+
 ## TODO
 
 - implement force flag

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,9 @@ pub const MAX_STACK: usize = 10;
 pub const ONE_FIXUP_PER_COMMIT_CONFIG_NAME: &str = "absorb.oneFixupPerCommit";
 pub const ONE_FIXUP_PER_COMMIT_DEFAULT: bool = false;
 
+pub const AUTO_STAGE_IF_NOTHING_STAGED_CONFIG_NAME: &str = "absorb.autoStageIfNothingStaged";
+pub const AUTO_STAGE_IF_NOTHING_STAGED_DEFAULT: bool = false;
+
 pub fn max_stack(repo: &git2::Repository) -> usize {
     match repo
         .config()
@@ -21,5 +24,15 @@ pub fn one_fixup_per_commit(repo: &git2::Repository) -> bool {
     {
         Ok(one_commit_per_fixup) => one_commit_per_fixup,
         _ => ONE_FIXUP_PER_COMMIT_DEFAULT,
+    }
+}
+
+pub fn auto_stage_if_nothing_staged(repo: &git2::Repository) -> bool {
+    match repo
+        .config()
+        .and_then(|config| config.get_bool(AUTO_STAGE_IF_NOTHING_STAGED_CONFIG_NAME))
+    {
+        Ok(val) => val,
+        _ => AUTO_STAGE_IF_NOTHING_STAGED_DEFAULT,
     }
 }


### PR DESCRIPTION
often times, i just want to try and absorb everything.

right now, this means an extra step of `git add .` before `git absorb`, and potentially a `git reset @` later if not everything was fixed up.

in this patch we remove both of the extra step for convenience: if nothing was staged, we stage everything, try to create fixups, and whatever's left uncommitted - we unstage.