### PR TITLE
introduce git config option `absorb.oneFixupPerCommit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ edit your local or global `.gitconfig` and add the following section
     maxStack=50 # Or any other reasonable value for your project
 ```
 
+### One fixup per fixable commit
+
+By default, git-absorb will generate separate fixup commits for every absorbable hunk. Instead, can use the `-F` flag to create only 1 fixup commit for all hunks that absorb into the same commit.
+To always have this behavior, set
+
+```ini
+[absorb]
+    oneFixupPerCommit = true
+```
+
 ## TODO
 
 - implement force flag

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,9 @@
 pub const MAX_STACK_CONFIG_NAME: &str = "absorb.maxStack";
 pub const MAX_STACK: usize = 10;
 
+pub const ONE_FIXUP_PER_COMMIT_CONFIG_NAME: &str = "absorb.oneFixupPerCommit";
+pub const ONE_FIXUP_PER_COMMIT_DEFAULT: bool = false;
+
 pub fn max_stack(repo: &git2::Repository) -> usize {
     match repo
         .config()
@@ -8,5 +11,15 @@ pub fn max_stack(repo: &git2::Repository) -> usize {
     {
         Ok(max_stack) if max_stack > 0 => max_stack as usize,
         _ => MAX_STACK,
+    }
+}
+
+pub fn one_fixup_per_commit(repo: &git2::Repository) -> bool {
+    match repo
+        .config()
+        .and_then(|config| config.get_bool(ONE_FIXUP_PER_COMMIT_CONFIG_NAME))
+    {
+        Ok(one_commit_per_fixup) => one_commit_per_fixup,
+        _ => ONE_FIXUP_PER_COMMIT_DEFAULT,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,12 @@
+pub const MAX_STACK_CONFIG_NAME: &str = "absorb.maxStack";
+pub const MAX_STACK: usize = 10;
+
+pub fn max_stack(repo: &git2::Repository) -> usize {
+    match repo
+        .config()
+        .and_then(|config| config.get_i64(MAX_STACK_CONFIG_NAME))
+    {
+        Ok(max_stack) if max_stack > 0 => max_stack as usize,
+        _ => MAX_STACK,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,7 +113,7 @@ fn main() {
         ));
     }
 
-    if let Err(e) = git_absorb::run(&git_absorb::Config {
+    if let Err(e) = git_absorb::run(&mut git_absorb::Config {
         dry_run: args.is_present("dry-run"),
         force: args.is_present("force"),
         base: args.value_of("base"),

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -2,18 +2,7 @@ use anyhow::{anyhow, Result};
 
 use std::collections::HashMap;
 
-pub const MAX_STACK_CONFIG_NAME: &str = "absorb.maxStack";
-pub const MAX_STACK: usize = 10;
-
-fn max_stack(repo: &git2::Repository) -> usize {
-    match repo
-        .config()
-        .and_then(|config| config.get_i64(MAX_STACK_CONFIG_NAME))
-    {
-        Ok(max_stack) if max_stack > 0 => max_stack as usize,
-        _ => MAX_STACK,
-    }
-}
+use crate::config;
 
 pub fn working_stack<'repo>(
     repo: &'repo git2::Repository,
@@ -87,7 +76,7 @@ pub fn working_stack<'repo>(
                 break;
             }
         }
-        if ret.len() == max_stack(repo) && user_provided_base.is_none() {
+        if ret.len() == config::max_stack(repo) && user_provided_base.is_none() {
             warn!(logger, "stack limit reached, use --base or configure absorb.maxStack to override";
                   "limit" => ret.len());
             break;
@@ -230,14 +219,17 @@ mod tests {
     #[test]
     fn test_stack_stops_at_configured_limit() {
         let (_dir, repo) = init_repo();
-        let commits = empty_commit_chain(&repo, "HEAD", &[], MAX_STACK + 2);
+        let commits = empty_commit_chain(&repo, "HEAD", &[], config::MAX_STACK + 2);
         repo.config()
             .unwrap()
-            .set_i64(MAX_STACK_CONFIG_NAME, (MAX_STACK + 1) as i64)
+            .set_i64(
+                config::MAX_STACK_CONFIG_NAME,
+                (config::MAX_STACK + 1) as i64,
+            )
             .unwrap();
 
         assert_stack_matches_chain(
-            MAX_STACK + 1,
+            config::MAX_STACK + 1,
             &working_stack(&repo, None, false, &empty_slog()).unwrap(),
             &commits,
         );


### PR DESCRIPTION
added git config option to `-F` by default.
moved git config-related stuff into config.rs 

related #19
related #91
