### PR TITLE
introduce git config option `absorb.fixupTargetAlwaysSHA`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,15 @@ By default, git-absorb will only consider files that you've staged to the index 
 
 which tells git-absorb, when no changes are staged, to auto-stage them all, create fixup commits where possible, and unstage remaining changes from the index.
 
+### Fixup target always SHA
+
+By default, git-absorb will create fixup commits with their messages pointing to the target commit's summary, and if there are duplicate summaries, will fallback to pointing to the target's SHA. Instead, can always point to the target's SHA via:
+
+```ini
+[absorb]
+    fixupTargetAlwaysSHA = true
+```
+
 ## TODO
 
 - implement force flag

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,9 @@ pub const ONE_FIXUP_PER_COMMIT_DEFAULT: bool = false;
 pub const AUTO_STAGE_IF_NOTHING_STAGED_CONFIG_NAME: &str = "absorb.autoStageIfNothingStaged";
 pub const AUTO_STAGE_IF_NOTHING_STAGED_DEFAULT: bool = false;
 
+pub const FIXUP_TARGET_ALWAYS_SHA_CONFIG_NAME: &str = "absorb.fixupTargetAlwaysSHA";
+pub const FIXUP_TARGET_ALWAYS_SHA_DEFAULT: bool = false;
+
 pub fn max_stack(repo: &git2::Repository) -> usize {
     match repo
         .config()
@@ -34,5 +37,15 @@ pub fn auto_stage_if_nothing_staged(repo: &git2::Repository) -> bool {
     {
         Ok(val) => val,
         _ => AUTO_STAGE_IF_NOTHING_STAGED_DEFAULT,
+    }
+}
+
+pub fn fixup_target_always_sha(repo: &git2::Repository) -> bool {
+    match repo
+        .config()
+        .and_then(|config| config.get_bool(FIXUP_TARGET_ALWAYS_SHA_CONFIG_NAME))
+    {
+        Ok(val) => val,
+        _ => FIXUP_TARGET_ALWAYS_SHA_DEFAULT,
     }
 }


### PR DESCRIPTION
hey sorry so many PRs, this is the last one i've had cooking for now :D probably should've submitted earlier, i see you've bumped the version already. will do next time.

i've gotten used to SHAs and find them clearer & faster to identify than commit summaries,
simply because the messages can be similar meanwhile shas differ very quickly.
