### PR TITLE
Apply cargo clippy lints

### DIFF
--- a/src/commute.rs
+++ b/src/commute.rs
@@ -77,10 +77,8 @@ where
         // to be reverse line order (bottom to top), which also
         // happens to be reverse of the order they're stored
         .rev()
-        .fold(Some(after.clone()), |after, next| {
-            after
-                .and_then(|after| commute(next, &after))
-                .map(|(commuted_after, _)| commuted_after)
+        .try_fold(after.clone(), |after, next| {
+            commute(next, &after).map(|(commuted_after, _)| commuted_after)
         })
 }
 


### PR DESCRIPTION
Cargo clippy told me that in a bunch of spots we did not need to pass in references as they would be immediately dereferenced anyways (https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow)
and that we could use try_fold() instead of fold() for handling the Option (https://rust-lang.github.io/rust-clippy/master/index.html#/manual_try_fold)