### PR TITLE
Don't sort hunks based on dest_commit.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,6 @@ fn run_with_repo(logger: &slog::Logger, config: &Config, repo: &git2::Repository
 
     let target_always_sha: bool = config::fixup_target_always_sha(repo);
 
-    hunks_with_commit.sort_by_key(|h| h.dest_commit.id());
     // * apply all hunks that are going to be fixed up into `dest_commit`
     // * commit the fixup
     // * repeat for all `dest_commit`s


### PR DESCRIPTION
Hey!

I kept running into #116 and I finally had some time to sit down and bisect with a small repro I had available. I haven't tested with the repro from #116 but I believe it is the same issue. 

I hope I'll have some time in the next {weeks|months} to open a PR to fix the now broken `--one-fixup-per-commit` feature (not 100% broken, but it doesn't work as advertised in _some_ cases) and add some tests to catch such issues in the future.