### PR TITLE
Support annotated tags given as base ref

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -32,7 +32,9 @@ pub fn working_stack<'repo>(
 
     let base_commit = match user_provided_base {
         // https://github.com/rust-lang/rfcs/issues/1815
-        Some(commitish) => Some(repo.find_commit(repo.revparse_single(commitish)?.id())?),
+        // user_provided_base isn't guaranteed to be a commit hash, so peel until a
+        // commit is found.
+        Some(commitish) => Some(repo.revparse_single(commitish)?.peel_to_commit()?),
         None => None,
     };
 

--- a/test/create.sh
+++ b/test/create.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# git-absorb binary path
+if [ $# -eq 0 ]; then
+    GIT_ABSORB_BIN="git absorb"
+else
+    GIT_ABSORB_BIN=$1
+fi
+
+
+README_FILE=README.md
+GIT_ANNOTATED_TAG="annotated-tag"
+
+# initialize a git repository
+git init
+
+# commit 1: create a sample file
+touch ${README_FILE}
+# commit 1: stage change
+git add ${README_FILE}
+# commit 1: create initial commit
+git commit -m 'Initial commit'
+
+# commit 2: update file
+cat <<EOF >| ${README_FILE}
+# readme
+
+Testing
+
+## header 2: part 1
+
+Header 2 testing. part 1
+
+## header 2: part 2
+
+Header 2 testing. part 2
+EOF
+# commit 2: stage updates
+git add ${README_FILE}
+# commit 2: create commit
+git commit -m 'Update readme'
+
+# commit 2: make this commit as annotated commit
+git tag -a ${GIT_ANNOTATED_TAG} -m 'my annotated tag'
+
+# commit 3: insert lines in the middle
+ed ${README_FILE} <<< '9i
+### header 3: part 1
+
+this is header 3
+
+.
+w
+q
+'
+# commit 3: stage changes
+git add ${README_FILE}
+# commit 3: create commit
+git commit -m 'More updates'
+
+# commit 4: insert additional lines
+ed ${README_FILE} <<< '7d
+7i
+Header 2 testing.
+
+foo
+
+part 1
+.
+w
+q'
+# commit 4: stage changes
+git add ${README_FILE}
+# commit 4: create commit
+git commit -m 'Commute commit'
+
+# commit 5: create the diff that'll commute
+ed ${README_FILE} <<< '9d
+9i
+foobar
+.
+w
+q'
+# commit 5: stage change
+git add -u ${README_FILE}
+# commit 5: try to absorb
+${GIT_ABSORB_BIN} -v --base ${GIT_ANNOTATED_TAG}


### PR DESCRIPTION
Improve the types of refspecs git-absorb knows how to parse that are
given via the '--base' flag.

This fixes the following:

    # create an annotated tag
    $ git tag -a 'annotated-tag' -m 'My annotated tag description'

    # make + stage some changes
    (...)

    # try to absorb the changes
    $ git absorb --base annotated-tag

According to the Git docs:

    > Git supports two types of tags: lightweight and annotated.
    >
    > A lightweight tag is very much like a branch that doesn't
    > change-it's just a pointer to a specific commit.
    >
    > Annotated tags, however, are stored as full objects in the Git
    > database.

This meant that when passing an annotated tag via '--base', calling
git2::Repository::find_commit would fail since the given object would
be of the incorrect type:

    > the requested type does not match the type in the ODB

However, eventually if we keep unpeeling, we would encounter the
corresponding commit.

Use git2::Object::peel_to_commit instead of simply peeling once
via 'find_commit' to ensure that peeling is performed recursively
until a commit is found.