### PR TITLE
Remove slog-async dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,21 +151,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,7 +227,6 @@ dependencies = [
  "git2",
  "memchr",
  "slog",
- "slog-async",
  "slog-term",
  "tempfile",
 ]
@@ -481,18 +465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
-name = "slog-async"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c8038f898a2c79507940990f05386455b3a317d8f18d4caea7cbc3d5096b84"
-dependencies = [
- "crossbeam-channel",
- "slog",
- "take_mut",
- "thread_local",
-]
-
-[[package]]
 name = "slog-term"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,12 +493,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ clap_complete = "4"
 clap_complete_nushell = "4"
 slog = "2.5"
 slog-term = "2.6"
-slog-async = "2.5"
 memchr = "2.3"
 anyhow = "1.0"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,8 @@ fn main() {
 
     let decorator = slog_term::TermDecorator::new().build();
     let drain = slog_term::FullFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
+    let drain = std::sync::Mutex::new(drain).fuse();
+
     let drain = slog::LevelFilter::new(
         drain,
         if verbose {


### PR DESCRIPTION
According to the slog-term docs:

    > PlainSync Decorator implementation
    >
    > This implementation is exactly like PlainDecorator but it takes
    > care of synchronizing writes to io.

Since we care about colouring, wrap a slog_term::TermDecorator in a std::sync::Mutex so that coloured output is still maintained.

This ensures that log messages will not be dropped when the logging rate exceeds the backend's ability to drain (as the previous slog-async backend could do). Previously when this occurred, the log output would show the following:

    slog-async: logger dropped messages due to channel overflow

An alternative might be to keep the slog-async dependency but use slog_async::OverflowStrategy::Block to ensure that overflowing writes will block, rather than forcing each write through the mutex.

Fixes #131