### PR TITLE
rebase: use --update-refs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,7 +370,7 @@ fn run_with_repo(config: &Config, repo: &git2::Repository) -> Result<()> {
         assert!(number_of_parents <= 1);
 
         let mut command = Command::new("git");
-        command.args(["rebase", "--interactive", "--autosquash", "--autostash"]);
+        command.args(["rebase", "--interactive", "--autosquash", "--autostash", "--update-refs"]);
 
         if number_of_parents == 0 {
             command.arg("--root");


### PR DESCRIPTION
Introduced in Git 2.38 (1), the --update-refs option to git-rebase will move refs whose commits are rewritten in a rebase. This behavior is particularly useful when using stacked branches.

When git-absorb is called with --and-rebase, add this option to the rebase call.

(1): 900b50c242 (rebase: add --update-refs option, 2022-07-19)