### PR TITLE
Create default config object for easier tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -556,7 +556,7 @@ mod tests {
             base: None,
             and_rebase: false,
             whole_file: false,
-            one_fixup_per_commit: true,
+            one_fixup_per_commit: false,
             logger: &logger,
         };
         run_with_repo(&config, &ctx.repo).unwrap();
@@ -584,14 +584,14 @@ mod tests {
             base: None,
             and_rebase: false,
             whole_file: false,
-            one_fixup_per_commit: true,
+            one_fixup_per_commit: false,
             logger: &logger,
         };
         run_with_repo(&config, &ctx.repo).unwrap();
 
         let mut revwalk = ctx.repo.revwalk().unwrap();
         revwalk.push_head().unwrap();
-        assert_eq!(revwalk.count(), 2);
+        assert_eq!(revwalk.count(), 3);
 
         assert!(nothing_left_in_index(&ctx.repo).unwrap());
     }
@@ -612,14 +612,14 @@ mod tests {
             base: None,
             and_rebase: false,
             whole_file: false,
-            one_fixup_per_commit: true,
+            one_fixup_per_commit: false,
             logger: &logger,
         };
         run_with_repo(&config, &ctx.repo).unwrap();
 
         let mut revwalk = ctx.repo.revwalk().unwrap();
         revwalk.push_head().unwrap();
-        assert_eq!(revwalk.count(), 2);
+        assert_eq!(revwalk.count(), 3);
 
         assert!(nothing_left_in_index(&ctx.repo).unwrap());
     }
@@ -646,14 +646,14 @@ mod tests {
             base: None,
             and_rebase: false,
             whole_file: false,
-            one_fixup_per_commit: true,
+            one_fixup_per_commit: false,
             logger: &logger,
         };
         run_with_repo(&config, &ctx.repo).unwrap();
 
         let mut revwalk = ctx.repo.revwalk().unwrap();
         revwalk.push_head().unwrap();
-        assert_eq!(revwalk.count(), 2);
+        assert_eq!(revwalk.count(), 3);
 
         assert!(nothing_left_in_index(&ctx.repo).unwrap());
     }
@@ -799,7 +799,7 @@ mod tests {
             base: None,
             and_rebase: false,
             whole_file: false,
-            one_fixup_per_commit: true,
+            one_fixup_per_commit: false,
             logger: &logger,
         };
         run_with_repo(&config, &ctx.repo).unwrap();
@@ -809,11 +809,11 @@ mod tests {
         revwalk.push_head().unwrap();
 
         let oids: Vec<git2::Oid> = revwalk.by_ref().collect::<Result<Vec<_>, _>>().unwrap();
-        assert_eq!(oids.len(), 2);
+        assert_eq!(oids.len(), 3);
 
         let commit = ctx.repo.find_commit(oids[0]).unwrap();
         let actual_msg = commit.summary().unwrap();
-        let expected_msg = format!("fixup! {}", oids[1]);
+        let expected_msg = format!("fixup! {}", oids.last().unwrap());
         assert_eq!(actual_msg, expected_msg);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -495,16 +495,7 @@ mod tests {
         // run 'git-absorb'
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
-        let config = Config {
-            dry_run: false,
-            force_author: false,
-            force: false,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
-            one_fixup_per_commit: false,
-            logger: &logger,
-        };
+        let config = default_config(&logger);
         run_with_repo(&config, &ctx.repo).unwrap();
 
         let mut revwalk = ctx.repo.revwalk().unwrap();
@@ -522,14 +513,8 @@ mod tests {
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
         let config = Config {
-            dry_run: false,
-            force_author: false,
-            force: false,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
             one_fixup_per_commit: true,
-            logger: &logger,
+            ..default_config(&logger)
         };
         run_with_repo(&config, &ctx.repo).unwrap();
 
@@ -549,16 +534,7 @@ mod tests {
         // run 'git-absorb'
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
-        let config = Config {
-            dry_run: false,
-            force_author: false,
-            force: false,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
-            one_fixup_per_commit: false,
-            logger: &logger,
-        };
+        let config = default_config(&logger);
         run_with_repo(&config, &ctx.repo).unwrap();
 
         let mut revwalk = ctx.repo.revwalk().unwrap();
@@ -578,14 +554,8 @@ mod tests {
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
         let config = Config {
-            dry_run: false,
             force_author: true,
-            force: false,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
-            one_fixup_per_commit: false,
-            logger: &logger,
+            ..default_config(&logger)
         };
         run_with_repo(&config, &ctx.repo).unwrap();
 
@@ -606,14 +576,8 @@ mod tests {
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
         let config = Config {
-            dry_run: false,
-            force_author: false,
             force: true,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
-            one_fixup_per_commit: false,
-            logger: &logger,
+            ..default_config(&logger)
         };
         run_with_repo(&config, &ctx.repo).unwrap();
 
@@ -639,16 +603,7 @@ mod tests {
         // run 'git-absorb'
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
-        let config = Config {
-            dry_run: false,
-            force_author: false,
-            force: false,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
-            one_fixup_per_commit: false,
-            logger: &logger,
-        };
+        let config = default_config(&logger);
         run_with_repo(&config, &ctx.repo).unwrap();
 
         let mut revwalk = ctx.repo.revwalk().unwrap();
@@ -688,16 +643,7 @@ mod tests {
         // run 'git-absorb'
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
-        let config = Config {
-            dry_run: false,
-            force_author: false,
-            force: false,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
-            one_fixup_per_commit: false,
-            logger: &logger,
-        };
+        let config = default_config(&logger);
         run_with_repo(&config, &ctx.repo).unwrap();
 
         let mut revwalk = ctx.repo.revwalk().unwrap();
@@ -725,16 +671,7 @@ mod tests {
         // run 'git-absorb'
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
-        let config = Config {
-            dry_run: false,
-            force_author: false,
-            force: false,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
-            one_fixup_per_commit: false,
-            logger: &logger,
-        };
+        let config = default_config(&logger);
         run_with_repo(&config, &ctx.repo).unwrap();
 
         let mut revwalk = ctx.repo.revwalk().unwrap();
@@ -760,16 +697,7 @@ mod tests {
         // run 'git-absorb'
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
-        let config = Config {
-            dry_run: false,
-            force_author: false,
-            force: false,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
-            one_fixup_per_commit: false,
-            logger: &logger,
-        };
+        let config = default_config(&logger);
         run_with_repo(&config, &ctx.repo).unwrap();
 
         let mut revwalk = ctx.repo.revwalk().unwrap();
@@ -792,16 +720,7 @@ mod tests {
         // run 'git-absorb'
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
-        let config = Config {
-            dry_run: false,
-            force_author: false,
-            force: false,
-            base: None,
-            and_rebase: false,
-            whole_file: false,
-            one_fixup_per_commit: false,
-            logger: &logger,
-        };
+        let config = default_config(&logger);
         run_with_repo(&config, &ctx.repo).unwrap();
         assert!(nothing_left_in_index(&ctx.repo).unwrap());
 
@@ -815,5 +734,18 @@ mod tests {
         let actual_msg = commit.summary().unwrap();
         let expected_msg = format!("fixup! {}", oids.last().unwrap());
         assert_eq!(actual_msg, expected_msg);
+    }
+
+    pub fn default_config(logger: &slog::Logger) -> Config {
+        Config {
+            dry_run: false,
+            force_author: false,
+            force: false,
+            base: None,
+            and_rebase: false,
+            whole_file: false,
+            one_fixup_per_commit: false,
+            logger,
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,16 +89,18 @@ fn main() {
         ));
     }
 
-    if let Err(e) = git_absorb::run(&git_absorb::Config {
-        dry_run,
-        force_author,
-        force,
-        base: base.as_deref(),
-        and_rebase,
-        whole_file,
-        one_fixup_per_commit,
-        logger: &logger,
-    }) {
+    if let Err(e) = git_absorb::run(
+        &logger,
+        &git_absorb::Config {
+            dry_run,
+            force_author,
+            force,
+            base: base.as_deref(),
+            and_rebase,
+            whole_file,
+            one_fixup_per_commit,
+        },
+    ) {
         crit!(logger, "absorb failed"; "err" => e.to_string());
         // wait for async logger to finish writing messages
         drop(logger);


### PR DESCRIPTION
Extract builder for `Config` object with no special settings. Can be used to build objects for use in different tests.