### PR TITLE
Characterize base search behaviour

### DIFF
--- a/Documentation/git-absorb.adoc
+++ b/Documentation/git-absorb.adoc
@@ -118,11 +118,11 @@ STACK SIZE
 ~~~~~~~~~~
 
 When run without `--base`, git-absorb will only search for candidate
-commits to fixup within a certain range (by default 10). If you get an
-error like this:
+commits to fixup within a certain range (by default 10), or until the
+first non-HEAD branch is reached. If you get an error like this:
 
 .............................................................................
-WARN stack limit reached, limit: 10
+WARN stack limit reached, use --base or configure absorb.maxStack to override
 .............................................................................
 
 edit your local or global `.gitconfig` and add the following section:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Note: `cargo install` does not currently know how to install manpages ([cargo#27
 
 `git absorb` works by checking if two patches P1 and P2 *commute*, that is, if applying P1 before P2 gives the same result as applying P2 before P1.
 
-`git absorb` considers a range of commits ending at HEAD. The first commit can be specified explicitly with `--base <ref>`. By default the last 10 commits will be considered (see [Configuration](#configuration) below for how to change this).
+`git absorb` considers a range of commits ending at HEAD. The first commit can be specified explicitly with `--base <ref>`. Otherwise, commits are considered by walking HEAD's ancestors until reaching a non-HEAD branch or the default limit of 10 commits (see the CONFIGURATION section of [the documentation](Documentation/git-absorb.adoc#configuration) or the git-absorb manual page for how to change the limit).
 
 For each hunk in the index, `git absorb` will check if that hunk commutes with the last commit, then the one before that, etc. When it finds a commit that does not commute with the hunk, it infers that this is the right parent commit for this change, and the hunk is turned into a fixup commit. If the hunk commutes with all commits in the range, it means we have not found a suitable parent commit for this change; a warning is displayed, and this hunk remains uncommitted in the index. 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,6 +645,23 @@ mod tests {
         assert!(is_something_in_index);
     }
 
+    #[test]
+    fn attached_head_pointing_at_commit_on_a_second_branch() {
+        let ctx = repo_utils::prepare_and_stage();
+        repo_utils::add_branch(&ctx.repo, "second-branch");
+
+        // run 'git-absorb'
+        let drain = slog::Discard;
+        let logger = slog::Logger::root(drain, o!());
+        run_with_repo(&logger, &DEFAULT_CONFIG, &ctx.repo).unwrap();
+        let mut revwalk = ctx.repo.revwalk().unwrap();
+        revwalk.push_head().unwrap();
+
+        assert_eq!(revwalk.count(), 1); // nothing was committed
+        let is_something_in_index = !nothing_left_in_index(&ctx.repo).unwrap();
+        assert!(is_something_in_index);
+    }
+
     fn autostage_common(ctx: &repo_utils::Context, file_path: &PathBuf) -> (PathBuf, PathBuf) {
         // 1 modification w/o staging
         let path = ctx.join(&file_path);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,6 +624,27 @@ mod tests {
         assert!(is_something_in_index);
     }
 
+    #[test]
+    fn detached_head_pointing_at_branch_with_force_flag() {
+        let ctx = repo_utils::prepare_and_stage();
+        repo_utils::detach_head(&ctx);
+
+        // run 'git-absorb'
+        let drain = slog::Discard;
+        let logger = slog::Logger::root(drain, o!());
+        let config = Config {
+            force: true,
+            ..DEFAULT_CONFIG
+        };
+        run_with_repo(&logger, &config, &ctx.repo).unwrap();
+        let mut revwalk = ctx.repo.revwalk().unwrap();
+        revwalk.push_head().unwrap();
+
+        assert_eq!(revwalk.count(), 1); // nothing was committed
+        let is_something_in_index = !nothing_left_in_index(&ctx.repo).unwrap();
+        assert!(is_something_in_index);
+    }
+
     fn autostage_common(ctx: &repo_utils::Context, file_path: &PathBuf) -> (PathBuf, PathBuf) {
         // 1 modification w/o staging
         let path = ctx.join(&file_path);

--- a/src/tests/repo_utils.rs
+++ b/src/tests/repo_utils.rs
@@ -81,3 +81,10 @@ pub fn become_new_author(ctx: &Context) {
     config.set_str("user.name", "nobody2").unwrap();
     config.set_str("user.email", "nobody2@example.com").unwrap();
 }
+
+/// Detach HEAD from the current branch.
+pub fn detach_head(ctx: &Context) {
+    let head = ctx.repo.head().unwrap();
+    let head_commit = head.peel_to_commit().unwrap();
+    ctx.repo.set_head_detached(head_commit.id()).unwrap();
+}

--- a/src/tests/repo_utils.rs
+++ b/src/tests/repo_utils.rs
@@ -88,3 +88,11 @@ pub fn detach_head(ctx: &Context) {
     let head_commit = head.peel_to_commit().unwrap();
     ctx.repo.set_head_detached(head_commit.id()).unwrap();
 }
+
+/// Add another branch pointing at the current HEAD.
+/// Don't switch to it.
+pub fn add_branch(repo: &git2::Repository, branch_name: &str) {
+    let head = repo.head().unwrap();
+    let head_commit = head.peel_to_commit().unwrap();
+    repo.branch(branch_name, &head_commit, false).unwrap();
+}

--- a/src/tests/repo_utils.rs
+++ b/src/tests/repo_utils.rs
@@ -96,3 +96,11 @@ pub fn add_branch(repo: &git2::Repository, branch_name: &str) {
     let head_commit = head.peel_to_commit().unwrap();
     repo.branch(branch_name, &head_commit, false).unwrap();
 }
+
+/// Delete the branch with the given name.
+pub fn delete_branch(repo: &git2::Repository, branch_name: &str) {
+    let mut branch = repo
+        .find_branch(branch_name, git2::BranchType::Local)
+        .unwrap();
+    branch.delete().unwrap();
+}


### PR DESCRIPTION
While working on #145 I had trouble writing a test and ended up discovering what looked like undocumented behaviour: branches interrupt the search for a base commit (if not explicitly specified).
So I added some tests and updated the documentation.

Builds on my proposed refactoring around the configuration and logger objects, because it was convenient for me, but can be reworked.