### PR TITLE
Add --one-reflog-entry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Note: `cargo install` does not currently know how to install manpages ([cargo#27
 1. `git add` any changes that you want to absorb. By design, `git absorb` will only consider content in the git index (staging area).
 2. `git absorb`. This will create a sequence of commits on `HEAD`. Each commit will have a `fixup!` message indicating the message (if unique) or SHA of the commit it should be squashed into.
 3. If you are satisfied with the output, `git rebase -i --autosquash` to squash the `fixup!` commits into their predecessors. You can set the [`GIT_SEQUENCE_EDITOR`](https://stackoverflow.com/a/29094904) environment variable if you don't need to edit the rebase TODO file.
-4. If you are not satisfied (or if something bad happened), `git reset --soft` to the pre-absorption commit to recover your old state. (You can find the commit in question with `git reflog`.) And if you think `git absorb` is at fault, please [file an issue](https://github.com/tummychow/git-absorb/issues/new).
+4. If you are not satisfied (or if something bad happened), `git reset --soft` to the pre-absorption commit to recover your old state. (You can find the commit in question with `git reflog`. Alternatively, you can run `git absorb` with `--one-reflog-entry`, in which case the pre-absorption commit will be `HEAD@{1}`.) And if you think `git absorb` is at fault, please [file an issue](https://github.com/tummychow/git-absorb/issues/new).
 
 ## How it works (roughly)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ struct Cli {
     /// Only generate one fixup per commit
     #[clap(long, short = 'F')]
     one_fixup_per_commit: bool,
+    /// Only generate one reflog entry, no matter how many commits were made
+    #[clap(long, short = 'F')]
+    one_reflog_entry: bool,
 }
 
 fn main() {
@@ -59,6 +62,7 @@ fn main() {
         gen_completions,
         whole_file,
         one_fixup_per_commit,
+        one_reflog_entry,
     } = Cli::parse();
 
     if let Some(shell) = gen_completions {
@@ -109,6 +113,7 @@ fn main() {
             rebase_options: &rebase_options,
             whole_file,
             one_fixup_per_commit,
+            one_reflog_entry,
         },
     ) {
         crit!(logger, "absorb failed"; "err" => e.to_string());


### PR DESCRIPTION
This implements option (4) from #157, adding a command-line flag to make git-absorb create only a single reflog entry (instead of one per commit as it normally does).

This change would allow users to easily "undo" all of git-absorb's commits at once by doing `git reset HEAD@{1}`.

Fixes #157.