### PR TITLE
Imitate rebase to get similar reflog

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,9 +280,6 @@ fn run_with_repo(logger: &slog::Logger, config: &Config, repo: &git2::Repository
         None
     };
     if branch_name != None && !config.dry_run {
-        // To detach head with libgit2 default reflog message:
-        // repo.set_head_detached(head_commit.id())?;
-        // But since we want a fancy custom one:
         repo.reference(
             "HEAD",
             head_commit.id(),
@@ -445,9 +442,6 @@ fn run_with_repo(logger: &slog::Logger, config: &Config, repo: &git2::Repository
                 final_commit.id(),
                 "absorb (finish): updating branch ref to final result",
             )?;
-            // To reattach head with libgit2 default reflog message:
-            // repo.set_head(&branch_name)?;
-            // But since we want a fancy custom one:
             repo.reference_symbolic(
                 "HEAD",
                 &branch_name,


### PR DESCRIPTION
## What

This implements the idea from https://github.com/tummychow/git-absorb/pull/162#issuecomment-2711623921, i.e. we try to make reflog entries created by `git absorb` look similar to those created by `git rebase`.

## Why

The original intent of this was to make "undoing" an absorb invocation easier (#157). This change would fulfill that by ensuring the starting branch's reflog only gets a single entry resulting from the `git absorb` invocation, so that `git reset $(git branch --show-current)@{1}` would be enough to "undo" it.

But having reflog entries that are similarly clean as those of `git rebase` may also be a good idea beyond that (if nothing else, it certainly looks fancy).

## How

The easiest way to get reflog messages similar to rebase is to imitate its behavior as well, so that's what we're doing here:

In a similar vein to rebase's initial checkout of the base commit, we start out by detaching `HEAD` (if it wasn't detached already). We then perform all our operations in a way that keeps updating `HEAD` (in our case: create fixup commits, then rebase if user chose `--and-rebase`). Finally, at the end, we point the branch we started from (if any) to our final commit and reattach `HEAD` to it.

At the points where we update references ourselves (namely: detach `HEAD`, point branch to final commit, reattach `HEAD`), we provide custom reflog messages that follow the format of `git rebase`'s.

## Result

After a successul `git absorb --and-rebase`, we have a single reflog entry for our original branch:

```console
$ git reflog mybranch
e2f01e3 (HEAD -> mybranch) mybranch@{0}: absorb (finish): updating branch ref to final result
3849aee mybranch@{1}: [ previous reflog entry, doesn't matter ]
```

And the full log of operations bookended by `absorb (...):`-prefixed messages in `HEAD`'s reflog:

```console
$ git reflog
e2f01e3 (HEAD -> mybranch) HEAD@{0}: absorb (finish): returning to refs/heads/mybranch
e2f01e3 (HEAD -> mybranch) HEAD@{1}: rebase (fixup): Baz
a9c219e HEAD@{2}: rebase (pick): Baz
2ccd01c HEAD@{3}: rebase (pick): Bar
c648109 HEAD@{4}: rebase (fixup): Foo
daffe57 HEAD@{5}: rebase: fast-forward
b1fff8f HEAD@{6}: rebase (start): checkout b1fff8ff73c4f79e3e624750382f8af077597efd
a9dadfa HEAD@{7}: commit: fixup! Foo
c24e9ab HEAD@{8}: commit: fixup! Baz
3849aee HEAD@{9}: absorb (start): detaching HEAD
3849aee HEAD@{10}: [ previous reflog entry, doesn't matter ]
```

## Comparison to `git rebase`

Just to expand on what was already said in https://github.com/tummychow/git-absorb/pull/162#issuecomment-2711623921 and make it easier to compare, after an ordinary `git rebase` (not in the context of `git absorb`), we have reflogs like:

<details hidden>

<summary>Typical rebase reflogs</summary>

```console
$ git reflog mybranch
[...]
0a7d4fd mybranch@{38}: rebase (finish): refs/heads/mybranch onto 1a11b604e4856bd32382baac11f6cdfb9ca366c4
fcdcbfe mybranch@{39}: [ previous reflog entry, doesn't matter ]
```

and

```console
$ git reflog
[...]
0a7d4fd HEAD@{117}: rebase (finish): returning to refs/heads/mybranch
0a7d4fd HEAD@{118}: rebase (fixup): Baz
cb0bb22 HEAD@{119}: rebase (pick): Baz
ddf6ea9 HEAD@{120}: rebase (pick): Bar
70d3142 HEAD@{121}: rebase (fixup): Foo
daffe57 HEAD@{122}: rebase: fast-forward
1a11b60 HEAD@{123}: rebase (start): checkout 1a11b604e4856bd32382baac11f6cdfb9ca366c4
fcdcbfe HEAD@{124}: [ previous reflog entry, doesn't matter ]
```

</details>

## Drawbacks & other approaches

Personally, I don't really like that if an error or crash happens in the middle, the user ends up in a detached `HEAD` state with no instructions about what to do now. If something like that happens during `git rebase`, Git will at least print some extra information about it in `git status` etc., but I don't think we can imitate that too (?).

I'm wondering if it wouldn't be better to keep the same logic as before (i.e. no `HEAD` detachment etc.) and only manipulate the reflog after the fact to remove all the extra entries from the branch's reflog :thinking: But that seems like a hack, too...

## Misc

Fixes #157.