### PR TITLE
Quell warnings by removing unused Struct fields

### DIFF
--- a/src/commute.rs
+++ b/src/commute.rs
@@ -96,12 +96,10 @@ mod tests {
             added: owned::Block {
                 start: 2,
                 lines: Rc::new(vec![b"bar\n".to_vec()]),
-                trailing_newline: true,
             },
             removed: owned::Block {
                 start: 1,
                 lines: Rc::new(vec![]),
-                trailing_newline: true,
             },
         };
         // after hunk1: <<EOF
@@ -112,12 +110,10 @@ mod tests {
             added: owned::Block {
                 start: 1,
                 lines: Rc::new(vec![b"bar\n".to_vec()]),
-                trailing_newline: true,
             },
             removed: owned::Block {
                 start: 0,
                 lines: Rc::new(vec![]),
-                trailing_newline: true,
             },
         };
         // after hunk2: <<EOF
@@ -138,24 +134,20 @@ mod tests {
             added: owned::Block {
                 start: 1,
                 lines: Rc::new((&mut line).take(4).collect::<Vec<_>>()),
-                trailing_newline: true,
             },
             removed: owned::Block {
                 start: 0,
                 lines: Rc::new(vec![]),
-                trailing_newline: true,
             },
         };
         let hunk2 = owned::Hunk {
             added: owned::Block {
                 start: 1,
                 lines: Rc::new((&mut line).take(2).collect::<Vec<_>>()),
-                trailing_newline: true,
             },
             removed: owned::Block {
                 start: 0,
                 lines: Rc::new(vec![]),
-                trailing_newline: true,
             },
         };
 
@@ -171,24 +163,20 @@ mod tests {
             added: owned::Block {
                 start: 1,
                 lines: Rc::new(vec![]),
-                trailing_newline: true,
             },
             removed: owned::Block {
                 start: 4,
                 lines: Rc::new((&mut line).take(4).collect::<Vec<_>>()),
-                trailing_newline: true,
             },
         };
         let hunk2 = owned::Hunk {
             added: owned::Block {
                 start: 1,
                 lines: Rc::new(vec![]),
-                trailing_newline: true,
             },
             removed: owned::Block {
                 start: 2,
                 lines: Rc::new((&mut line).take(2).collect::<Vec<_>>()),
-                trailing_newline: true,
             },
         };
 
@@ -208,24 +196,20 @@ mod tests {
                 added: owned::Block {
                     start: 1,
                     lines: Rc::new(vec![b"bar\n".to_vec()]),
-                    trailing_newline: true,
                 },
                 removed: owned::Block {
                     start: 0,
                     lines: Rc::new(vec![]),
-                    trailing_newline: true,
                 },
             },
             owned::Hunk {
                 added: owned::Block {
                     start: 3,
                     lines: Rc::new(vec![b"bar\n".to_vec()]),
-                    trailing_newline: true,
                 },
                 removed: owned::Block {
                     start: 1,
                     lines: Rc::new(vec![]),
-                    trailing_newline: true,
                 },
             },
         ];
@@ -239,12 +223,10 @@ mod tests {
             added: owned::Block {
                 start: 5,
                 lines: Rc::new(vec![b"bar\n".to_vec()]),
-                trailing_newline: true,
             },
             removed: owned::Block {
                 start: 4,
                 lines: Rc::new(vec![]),
-                trailing_newline: true,
             },
         };
         // after hunk: <<EOF

--- a/src/owned.rs
+++ b/src/owned.rs
@@ -51,7 +51,6 @@ impl Diff {
 pub struct Block {
     pub start: usize,
     pub lines: Rc<Vec<Vec<u8>>>,
-    pub trailing_newline: bool,
 }
 #[derive(Debug, Clone)]
 pub struct Hunk {
@@ -133,12 +132,10 @@ impl Hunk {
             added: Block {
                 start: added_start,
                 lines: Rc::new(added_lines),
-                trailing_newline: added_trailing_newline,
             },
             removed: Block {
                 start: removed_start,
                 lines: Rc::new(removed_lines),
-                trailing_newline: removed_trailing_newline,
             },
         })
     }
@@ -206,9 +203,7 @@ impl Hunk {
 #[derive(Debug)]
 pub struct Patch {
     pub old_path: Vec<u8>,
-    pub old_id: git2::Oid,
     pub new_path: Vec<u8>,
-    pub new_id: git2::Oid,
     pub status: git2::Delta,
     pub hunks: Vec<Hunk>,
 }
@@ -221,14 +216,12 @@ impl Patch {
                 .path_bytes()
                 .map(Vec::from)
                 .ok_or_else(|| anyhow!("delta with empty old path"))?,
-            old_id: patch.delta().old_file().id(),
             new_path: patch
                 .delta()
                 .new_file()
                 .path_bytes()
                 .map(Vec::from)
                 .ok_or_else(|| anyhow!("delta with empty new path"))?,
-            new_id: patch.delta().new_file().id(),
             status: patch.delta().status(),
             hunks: Vec::with_capacity(patch.num_hunks()),
         };


### PR DESCRIPTION
When git-absorb is built, we're [beset by warnings](https://github.com/tummychow/git-absorb/actions/runs/13801064129/job/38603441059#step:3:201:~:text=warning%3A%20field%20%60trailing_newline,generated%202%20warnings):

```
warning: field `trailing_newline` is never read
  --> src/owned.rs:54:9
   |
51 | pub struct Block {
   |            ----- field in this struct
...
54 |     pub trailing_newline: bool,
   |         ^^^^^^^^^^^^^^^^
   |
   = note: `Block` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
   = note: `#[warn(dead_code)]` on by default

warning: fields `old_id` and `new_id` are never read
   --> src/owned.rs:209:9
    |
207 | pub struct Patch {
    |            ----- fields in this struct
208 |     pub old_path: Vec<u8>,
209 |     pub old_id: git2::Oid,
    |         ^^^^^^
210 |     pub new_path: Vec<u8>,
211 |     pub new_id: git2::Oid,
    |         ^^^^^^
    |
    = note: `Patch` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis

warning: `git-absorb` (lib) generated 2 warnings
```

Removing a few unused fields quiets them right up.