### PR TITLE
Quell Waiting for your editor to close the file... hint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -703,6 +703,7 @@ mod tests {
     fn and_rebase_flag() {
         let ctx = repo_utils::prepare_and_stage();
         repo_utils::set_config_option(&ctx.repo, "core.editor", "true");
+        repo_utils::set_config_option(&ctx.repo, "advice.waitingForEditor", "false");
 
         // run 'git-absorb'
         let drain = slog::Discard;
@@ -724,6 +725,7 @@ mod tests {
     fn and_rebase_flag_with_rebase_options() {
         let ctx = repo_utils::prepare_and_stage();
         repo_utils::set_config_option(&ctx.repo, "core.editor", "true");
+        repo_utils::set_config_option(&ctx.repo, "advice.waitingForEditor", "false");
 
         // run 'git-absorb'
         let drain = slog::Discard;


### PR DESCRIPTION
When the tests run, `git rebase` prints some hints to the console.
The exact placement varies (since the tests are run concurrently),
but looks something like

```
test stack::tests::test_stack_stops_at_merges ... ok
hint: Waiting for your editor to close the file... hint: Waiting for your editor to close the file... test tests::foreign_author_with_force_author_config ... ok
test tests::foreign_author_with_force_author_flag ... ok
```

Remove the hints by configuring each new git repo.