### PR TITLE
Mark pre-absorb commit with PRE_ABSORB_HEAD ref

### DIFF
--- a/Documentation/git-absorb.adoc
+++ b/Documentation/git-absorb.adoc
@@ -115,9 +115,9 @@ https://stackoverflow.com/a/29094904[GIT_SEQUENCE_EDITOR] environment
 variable if you don't need to edit the rebase TODO file.
 
 4. If you are not satisfied (or if something bad happened), `git reset
---soft` to the pre-absorption commit to recover your old state. (You can
-find the commit in question with `git reflog`.) And if you think
-`git absorb` is at fault, please
+--soft PRE_ABSORB_HEAD` to the pre-absorption commit to recover your old
+state. (You can also find the commit in question with `git reflog`.) And
+if you think `git absorb` is at fault, please
 https://github.com/tummychow/git-absorb/issues/new[file an issue].
 
 CONFIGURATION

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Note: `cargo install` does not currently know how to install manpages ([cargo#27
 1. `git add` any changes that you want to absorb. By design, `git absorb` will only consider content in the git index (staging area).
 2. `git absorb`. This will create a sequence of commits on `HEAD`. Each commit will have a `fixup!` message indicating the message (if unique) or SHA of the commit it should be squashed into.
 3. If you are satisfied with the output, `git rebase -i --autosquash` to squash the `fixup!` commits into their predecessors. You can set the [`GIT_SEQUENCE_EDITOR`](https://stackoverflow.com/a/29094904) environment variable if you don't need to edit the rebase TODO file.
-4. If you are not satisfied (or if something bad happened), `git reset --soft` to the pre-absorption commit to recover your old state. (You can find the commit in question with `git reflog`.) And if you think `git absorb` is at fault, please [file an issue](https://github.com/tummychow/git-absorb/issues/new).
+4. If you are not satisfied (or if something bad happened), `git reset --soft PRE_ABSORB_HEAD` will reset to the pre-absorption commit and recover your old state. (You can also find the commit in question with `git reflog`.) And if you think `git absorb` is at fault, please [file an issue](https://github.com/tummychow/git-absorb/issues/new).
 
 ## How it works (roughly)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -529,6 +529,8 @@ mod tests {
     fn multiple_fixups_per_commit() {
         let ctx = repo_utils::prepare_and_stage();
 
+        let actual_pre_absorb_commit = ctx.repo.head().unwrap().peel_to_commit().unwrap().id();
+
         // run 'git-absorb'
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
@@ -539,6 +541,9 @@ mod tests {
         assert_eq!(revwalk.count(), 3);
 
         assert!(nothing_left_in_index(&ctx.repo).unwrap());
+
+        let pre_absorb_ref_commit = ctx.repo.refname_to_id("PRE_ABSORB_HEAD").unwrap();
+        assert_eq!(pre_absorb_ref_commit, actual_pre_absorb_commit);
     }
 
     #[test]
@@ -807,6 +812,9 @@ mod tests {
         assert_eq!(revwalk.count(), 1);
         let is_something_in_index = !nothing_left_in_index(&ctx.repo).unwrap();
         assert!(is_something_in_index);
+
+        let pre_absorb_ref_commit = ctx.repo.references_glob("PRE_ABSORB_HEAD").unwrap().last();
+        assert!(matches!(pre_absorb_ref_commit, None));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,10 @@ fn run_with_repo(logger: &slog::Logger, config: &Config, repo: &git2::Repository
 
     let target_always_sha: bool = config::fixup_target_always_sha(repo);
 
+    if !config.dry_run {
+        repo.reference("PRE_ABSORB_HEAD", head_commit.id(), true, "")?;
+    }
+
     // * apply all hunks that are going to be fixed up into `dest_commit`
     // * commit the fixup
     // * repeat for all `dest_commit`s


### PR DESCRIPTION
This fixes #157 using the approach suggested in https://github.com/tummychow/git-absorb/issues/157#issuecomment-2707603889 and https://github.com/tummychow/git-absorb/issues/157#issuecomment-2716066828, i.e. marking the pre-absorption commit with a ref named `PRE_ABSORB_HEAD` before creating any fixup commits, thus allowing users to "undo" the last `git absorb` invocation by just doing `git reset --soft PRE_ABSORB_HEAD`.