### PR TITLE
Characterize user-facing log messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,8 +234,11 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "git2",
+ "iobuffer",
  "memchr",
+ "serde_json",
  "slog",
+ "slog-extlog",
  "slog-term",
  "tempfile",
 ]
@@ -265,6 +277,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "iobuffer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b2b69d767804b4df0810a059001309981588fbec64154f8ca032179b8a329c"
 
 [[package]]
 name = "is-terminal"
@@ -439,6 +457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "serde"
 version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,10 +483,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
+dependencies = [
+ "erased-serde",
+]
+
+[[package]]
+name = "slog-extlog"
+version = "8.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00caea52ddc6535e015114a7eb1d2483898f14d6f5110755c56c9f0d765fb71"
+dependencies = [
+ "erased-serde",
+ "iobuffer",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-json",
+]
+
+[[package]]
+name = "slog-json"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1e53f61af1e3c8b852eef0a9dee29008f55d6dd63794f3f12cef786cf0f219"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_json",
+ "slog",
+ "time",
+]
 
 [[package]]
 name = "slog-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,7 @@ memchr = "2.3"
 anyhow = "1.0"
 
 [dev-dependencies]
+iobuffer = "0.2.0"
+serde_json = "1.0.140"
+slog-extlog = "8.1.0"
 tempfile = "3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,7 +532,7 @@ mod tests {
 
     use super::*;
     mod log_utils;
-    mod repo_utils;
+    pub mod repo_utils;
 
     #[test]
     fn multiple_fixups_per_commit() {
@@ -929,18 +929,9 @@ mod tests {
 
         // create a fixup commit that 'git rebase' will act on if called
         let tree = repo_utils::stage_file_changes(&ctx, &path);
-        let signature = ctx.repo.signature().unwrap();
         let head_commit = ctx.repo.head().unwrap().peel_to_commit().unwrap();
-        ctx.repo
-            .commit(
-                Some("HEAD"),
-                &signature,
-                &signature,
-                &format!("fixup! {}\n", head_commit.id()),
-                &tree,
-                &[&head_commit],
-            )
-            .unwrap();
+        let fixup_message = format!("fixup! {}\n", head_commit.id());
+        repo_utils::commit(&ctx.repo, "HEAD", &fixup_message, &tree, &[&head_commit]);
 
         // stage one more change so 'git-absorb' won't exit early
         repo_utils::stage_file_changes(&ctx, &path);

--- a/src/tests/log_utils.rs
+++ b/src/tests/log_utils.rs
@@ -1,0 +1,53 @@
+#[cfg(test)]
+use serde_json::value::Value;
+use slog_extlog::slog_test;
+
+/// A logger that captures log messages for testing.
+pub struct CapturingLogger {
+    pub(crate) logger: slog::Logger,
+    buffer: iobuffer::IoBuffer,
+}
+
+impl CapturingLogger {
+    /// Create a new `CapturingLogger`.
+    pub fn new() -> Self {
+        let buffer = iobuffer::IoBuffer::new();
+        let logger = slog_test::new_test_logger(buffer.clone());
+        Self { logger, buffer }
+    }
+
+    /// Get the logs that have been captured.
+    pub fn logs(&mut self) -> Vec<Value> {
+        slog_test::read_json_values(&mut self.buffer)
+    }
+
+    /// Get log messages that would usually be visible when git-absorb is run.
+    ///
+    /// Used to filter out debug logs which are too detailed for most tests.
+    pub fn visible_logs(&mut self) -> Vec<Value> {
+        // let logs = slog_test::read_json_values(&mut self.buffer);
+        let logs = self.logs();
+        logs.iter()
+            .filter(|log| log["level"].as_str().unwrap().ne("DEBG"))
+            .map(|log| log.clone())
+            .collect()
+    }
+}
+
+/// Assert that the actual log messages match the expected log messages.
+///
+/// There must be the same number of items in `actual_logs` and `expected_logs`.
+/// The items are compared in order.
+/// Elements in `actual_logs` items that do not appear in `expected_logs` are ignored.
+pub fn assert_log_messages_are(actual_logs: Vec<Value>, expected_logs: Vec<&Value>) {
+    assert_eq!(
+        actual_logs.len(),
+        expected_logs.len(),
+        "Log lengths do not match. Found:\n{:?}",
+        actual_logs,
+    );
+
+    for (actual, expected) in actual_logs.iter().zip(expected_logs.iter()) {
+        slog_test::assert_json_matches(actual, expected);
+    }
+}


### PR DESCRIPTION
Contributes to #172, implementing

1. Capture INFO and worse log output in the lib.rs tests, to characterize the state of things now
2. Add additional tests at this level, to cover the various situations that can cause a change to not be absorbed