### PR TITLE
issue #129 - Adds new -m option for adding commit message body to generated fixups  

### DIFF
--- a/Documentation/git-absorb.adoc
+++ b/Documentation/git-absorb.adoc
@@ -90,6 +90,10 @@ OPTIONS
 --base <base>::
         Use this commit as the base of the absorb stack
 
+-m <MESSAGE>::
+--message <MESSAGE>::
+        A simple commit message body that will be used for **all** generated fixup commits.
+
 --gen-completions <SHELL>::
         Generate completions
         [possible values: bash, fish, nushell, zsh, powershell, elvish]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,11 +320,17 @@ fn run_with_repo(logger: &slog::Logger, config: &Config, repo: &git2::Repository
                 .stats()?;
             if !config.dry_run {
                 head_tree = new_head_tree;
+                let mut message = format!("fixup! {}\n", dest_commit_locator);
+                if let Some(m) = config.message.filter(|m| !m.is_empty()) {
+                    message.push('\n');
+                    message.push_str(m);
+                    message.push('\n');
+                };
                 head_commit = repo.find_commit(repo.commit(
                     Some("HEAD"),
                     &signature,
                     &signature,
-                    &format!("fixup! {}\n", dest_commit_locator),
+                    &message,
                     &head_tree,
                     &[&head_commit],
                 )?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -985,6 +985,59 @@ mod tests {
         assert_eq!(actual_msg, expected_msg);
     }
 
+    #[test]
+    fn fixup_message_option_left_out_sets_only_summary() {
+        let ctx = repo_utils::prepare_and_stage();
+
+        // run 'git-absorb'
+        let drain = slog::Discard;
+        let logger = slog::Logger::root(drain, o!());
+        run_with_repo(&logger, &DEFAULT_CONFIG, &ctx.repo).unwrap();
+        assert!(nothing_left_in_index(&ctx.repo).unwrap());
+
+        let mut revwalk = ctx.repo.revwalk().unwrap();
+        revwalk.push_head().unwrap();
+
+        let oids: Vec<git2::Oid> = revwalk.by_ref().collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(oids.len(), 3);
+
+        let fixup_commit = ctx.repo.find_commit(oids[0]).unwrap();
+        let fixed_up_commit = ctx.repo.find_commit(*oids.last().unwrap()).unwrap();
+        let actual_msg = fixup_commit.message().unwrap();
+        let expected_msg = fixed_up_commit.message().unwrap();
+        let expected_msg = format!("fixup! {}\n", expected_msg);
+        assert_eq!(actual_msg, expected_msg);
+    }
+
+    #[test]
+    fn fixup_message_option_provided_sets_message() {
+        let ctx = repo_utils::prepare_and_stage();
+
+        // run 'git-absorb'
+        let drain = slog::Discard;
+        let logger = slog::Logger::root(drain, o!());
+        let fixup_message_body = "git-absorb is my favorite git tool!";
+        let config = Config {
+            message: Some(fixup_message_body),
+            ..DEFAULT_CONFIG
+        };
+        run_with_repo(&logger, &config, &ctx.repo).unwrap();
+        assert!(nothing_left_in_index(&ctx.repo).unwrap());
+
+        let mut revwalk = ctx.repo.revwalk().unwrap();
+        revwalk.push_head().unwrap();
+
+        let oids: Vec<git2::Oid> = revwalk.by_ref().collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(oids.len(), 3);
+
+        let fixup_commit = ctx.repo.find_commit(oids[0]).unwrap();
+        let fixed_up_commit = ctx.repo.find_commit(*oids.last().unwrap()).unwrap();
+        let actual_msg = fixup_commit.message().unwrap();
+        let expected_msg = fixed_up_commit.message().unwrap();
+        let expected_msg = format!("fixup! {}\n\n{}\n", expected_msg, fixup_message_body);
+        assert_eq!(actual_msg, expected_msg);
+    }
+
     const DEFAULT_CONFIG: Config = Config {
         dry_run: false,
         force_author: false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub struct Config<'a> {
     pub rebase_options: &'a Vec<&'a str>,
     pub whole_file: bool,
     pub one_fixup_per_commit: bool,
+    pub message: Option<&'a str>,
 }
 
 pub fn run(logger: &slog::Logger, config: &Config) -> Result<()> {
@@ -987,5 +988,6 @@ mod tests {
         rebase_options: &Vec::new(),
         whole_file: false,
         one_fixup_per_commit: false,
+        message: None,
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ struct Cli {
     /// Only generate one fixup per commit
     #[clap(long, short = 'F')]
     one_fixup_per_commit: bool,
+    /// Commit message body that is given to all fixup commits
+    #[clap(long, short)]
+    message: Option<String>,
 }
 
 fn main() {
@@ -59,6 +62,7 @@ fn main() {
         gen_completions,
         whole_file,
         one_fixup_per_commit,
+        message,
     } = Cli::parse();
 
     if let Some(shell) = gen_completions {
@@ -109,6 +113,7 @@ fn main() {
             rebase_options: &rebase_options,
             whole_file,
             one_fixup_per_commit,
+            message: message.as_deref(),
         },
     ) {
         crit!(logger, "absorb failed"; "err" => e.to_string());


### PR DESCRIPTION
This option is used to specify the commit body for generated fixup commits.

Closes #129 .