### PR TITLE
Alternative output format when printing the created fixup commits 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,7 @@ fn run_with_repo(logger: &slog::Logger, config: &Config, repo: &git2::Repository
                 let commit_short_id = commit_short_id.as_str().expect("the commit short id is always a valid ascii string by definition (its a hex string)");
                 info!(logger, "committed";
                       "commit" => commit_short_id,
+                      "fixup" => dest_commit_locator,
                       "header" => format!("+{},-{}", diff.insertions(), diff.deletions()),
                 );
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,8 +327,10 @@ fn run_with_repo(logger: &slog::Logger, config: &Config, repo: &git2::Repository
                     &head_tree,
                     &[&head_commit],
                 )?)?;
+                let commit_short_id = head_commit.as_object().short_id()?;
+                let commit_short_id = commit_short_id.as_str().expect("the commit short id is always a valid ascii string by definition (its a hex string)");
                 info!(logger, "committed";
-                      "commit" => head_commit.id().to_string(),
+                      "commit" => commit_short_id,
                       "header" => format!("+{},-{}", diff.insertions(), diff.deletions()),
                 );
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,12 @@ fn main() {
     }
 
     let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::FullFormat::new(decorator).build().fuse();
+    let drain = slog_term::FullFormat::new(decorator)
+        // Don't write a timestamp, as requested in #126
+        // I am currently running git absorb myself, I know what time it is :)
+        .use_custom_timestamp(|_| Ok(()))
+        .build()
+        .fuse();
     let drain = std::sync::Mutex::new(drain).fuse();
 
     let drain = slog::LevelFilter::new(


### PR DESCRIPTION
Please read the commit messages, especially the last one:

```
Do note that if you used the absorb.fixupTargetAlwaysSHA option (or its cli equvalient),
you will see the commit hash instead.

I don't think its interesting enough to fix (maybe this is even the intended behaviour?)

You decide!
```