### PR TITLE
and_rebase: use workdir() rather than .path().parent()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,7 +485,7 @@ fn run_with_repo(logger: &slog::Logger, config: &Config, repo: &git2::Repository
             // This simplifies writing tests that execute from within git-absorb's source directory
             // but operate on temporary repositories created elsewhere.
             // (The tests could explicitly change directories, but then must be serialized.)
-            let repo_path = repo.path().parent().and_then(Path::to_str);
+            let repo_path = repo.workdir().and_then(Path::to_str);
             match repo_path {
                 Some(path) => {
                     command.args(["-C", path]);


### PR DESCRIPTION
Currently the and_rebase code uses `.path().parent()`  however the gitdir for worktrees lives in `worktrees/<worktree>` of the main gitdir so our resolved path becomes something like `.git/worktrees`. I feel `.workdir()` matches the intent of this code better and it fixes the worktree case.


Test script:
```sh
#!/bin/bash
set -e

# Set up repo
git init foo
echo -e "Hello world\nHello git\nHello mars" > foo/readme.txt
git -C foo add .
git -C foo commit -m "Initial commit"

# set up worktree
git -C foo worktree add ../bar
echo -e "Hello world\nHello git2\nHello mars" > bar/readme.txt
git -C bar commit -am "Initial commit"

# create edit
echo -e "Hello world\nHello git-absorb\nHello mars" > bar/readme.txt
git -C bar add .
( cd bar ; git absorb -r )
```

Old behavior:
```
% bash create.sh
...
[bar b0bb048] Initial commit
 1 file changed, 1 insertion(+), 1 deletion(-)
May 09 04:59:28.667 INFO committed, header: +1,-1, commit: 16a9760ce906df0ef0b56d2820d24b4421003782
fatal: this operation must be run in a work tree
```

New behavior:
launches git rebase interactive

The tests all still pass for me locally. 
