### PR TITLE
Add --no-limit option

### DIFF
--- a/Documentation/git-absorb.adoc
+++ b/Documentation/git-absorb.adoc
@@ -51,6 +51,15 @@ FLAGS
 --dry-run::
         Don't make any actual changes
 
+--no-limit::
+        Remove absorb stack limit. Has no effect when used with `--base`
+        +
+        This will consider all commits until
+        either root, merge commit, or a commit by other author
+        (unless `--force-author` is used)
+        +
+        Which is why you should be careful when using this flag.
+
 --force-author::
         Generate fixups to commits not made by you
 
@@ -152,6 +161,8 @@ edit your local or global `.gitconfig` and add the following section:
 [absorb]
     maxStack=50 # Or any other reasonable value for your project
 .............................................................................
+
+Stack size can also be disabled temporarily for one command (see `--no-limit`)
 
 ONE FIXUP PER FIXABLE COMMIT
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,9 @@ struct Cli {
     /// Don't make any actual changes
     #[clap(long, short = 'n')]
     dry_run: bool,
+    /// Remove absorb stack limit. Be careful with this
+    #[clap(long)]
+    no_limit: bool,
     /// Generate fixups to commits not made by you
     #[clap(long)]
     force_author: bool,
@@ -58,6 +61,7 @@ fn main() {
     let Cli {
         base,
         dry_run,
+        no_limit,
         force_author,
         force_detach,
         force,
@@ -120,6 +124,7 @@ fn main() {
             base: base.as_deref(),
             and_rebase,
             rebase_options: &rebase_options,
+            no_limit,
             whole_file,
             one_fixup_per_commit,
             squash,


### PR DESCRIPTION
disables stack limit,
so revwalk reaches first merge commit, or other author, or actual root

this is basically --root, but isn't named --root because --no-limit doesn't automatically mean your absorb base is the root commit because you can't absorb through a merge,
or other author without the --force-author flag

but it means that absorb stack will go as far as possible, allowing linear histories to even reach real root commit

should be used carefully in case theres like 100k commits without any merges and from a single author...

Closes: #118