### PR TITLE
Add target commit id for would have commit fixup log msg

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,7 @@ fn main() {
             one_fixup_per_commit,
             squash,
             message: message.as_deref(),
+            verbose,
         },
     ) {
         crit!(logger, "absorb failed"; "err" => e.to_string());


### PR DESCRIPTION
When running a dry run, print target commit hashes to be able to review them later.

```
$ ./target/debug/git-absorb -b master --force-author -n
would have committed, header: 1 insertion(+), 1 deletion(-), commit: 63cc343, fixup: Add target commit id for would have commit fixup log msg

$ ./target/debug/git-absorb -b master --force-author -n -v
repository found, path: /home/sitano/Projects/git-absorb/.git/, line: 31, module: git_absorb
head found, head: refs/heads/ivan/fixup_verbose, line: 26, module: git_absorb::stack
head pushed, head: refs/heads/ivan/fixup_verbose, line: 45, module: git_absorb::stack
commit hidden, commit: debdcd28d9db2ac6b36205bda307b6693a6a91e7, line: 57, module: git_absorb::stack
commit pushed onto stack, commit: 63cc3437edc9981e6e30d9be7ccf923630dc2fa4, line: 99, module: git_absorb::stack
next hunk, path: src/lib.rs, header: -357,1 +357,1, line: 144, module: git_absorb
preceding hunks: 0/0, to commute: -357,1 +357,1, to apply: -357,1 +357,1, line: 189, module: git_absorb
found noncommutative commit by conflict, commit: 63cc3437edc9981e6e30d9be7ccf923630dc2fa4, line: 254, module: git_absorb
would have committed, header: 1 insertion(+), 1 deletion(-), commit: 63cc3437edc9981e6e30d9be7ccf923630dc2fa4, fixup: Add target commit id for would have commit fixup log msg, line: 633, module: git_absorb
```